### PR TITLE
Update work-around for Protégé 5.5

### DIFF
--- a/doc/installing_factplusplus.md
+++ b/doc/installing_factplusplus.md
@@ -5,6 +5,7 @@ Fortunately a solution has been posted on http://protege-project.136.n4.nabble.c
 
 Instructions
 ------------
+0. Ensure that "Microsoft Visual C++ Redistributable for Visual Studio" is installed.
 1. Download [OpenJDK](https://jdk.java.net/13/) and extract the zip file.
 2. Download the [FaCT++ plugin](https://bitbucket.org/dtsarkov/factplusplus/downloads/uk.ac.manchester.cs.owl.factplusplus-P5.x-v1.6.5.jar) and save it in the Protégé plugin directory.
 3. Download the [fix](https://gist.githubusercontent.com/jpi-seb/12627bba6509a85a9c75afd262e78469/raw/28016a4b292c94549623c71dff4028cbea274a29/factplusplus-P5.x-v1.6.5-manifest-fix-win10.txt) to the same directory.


### PR DESCRIPTION
Add a note to the work-around to ensure the required DLLs are installed. Although the instructions work for updating the plug-in, starting Protégé will still fail with an ambiguous error due to missing dependent DLLs.