### PR TITLE
Move dimensionone to metrology

### DIFF
--- a/middle/isq.owl
+++ b/middle/isq.owl
@@ -1161,11 +1161,11 @@ Temperature is a relative quantity that can be used to express temperature diffe
                 </owl:allValuesFrom>
             </owl:Restriction>
         </rdfs:subClassOf>
-        <annotations:EMMO_21ae69b4_235e_479d_8dd8_4f756f694c1b>Angle</annotations:EMMO_21ae69b4_235e_479d_8dd8_4f756f694c1b>
+        <annotations:EMMO_21ae69b4_235e_479d_8dd8_4f756f694c1b>PlaneAngle</annotations:EMMO_21ae69b4_235e_479d_8dd8_4f756f694c1b>
         <annotations:EMMO_6dd685dd_1895_46e4_b227_be9f7d643c25>http://dbpedia.org/page/Angle</annotations:EMMO_6dd685dd_1895_46e4_b227_be9f7d643c25>
         <annotations:EMMO_70fe84ff_99b6_4206_a9fc_9a8931836d84>Ratio of circular arc length to radius.</annotations:EMMO_70fe84ff_99b6_4206_a9fc_9a8931836d84>
         <annotations:EMMO_fe015383_afb3_44a6_ae86_043628697aa2>https://doi.org/10.1351/goldbook.A00346</annotations:EMMO_fe015383_afb3_44a6_ae86_043628697aa2>
-        <rdfs:label xml:lang="en">PlaneAngle</rdfs:label>
+        <rdfs:label xml:lang="en">Angle</rdfs:label>
     </owl:Class>
     
 

--- a/middle/isq.owl
+++ b/middle/isq.owl
@@ -257,21 +257,6 @@ It provides the connection between the physical world, materials characterisatio
     
 
 
-    <!-- http://emmo.info/emmo/middle/isq#EMMO_3227b821_26a5_4c7c_9c01_5c24483e0bd0 -->
-
-    <owl:Class rdf:about="http://emmo.info/emmo/middle/isq#EMMO_3227b821_26a5_4c7c_9c01_5c24483e0bd0">
-        <owl:equivalentClass>
-            <owl:Restriction>
-                <owl:onProperty rdf:resource="http://emmo.info/emmo/middle/perceptual#EMMO_23b579e1_8088_45b5_9975_064014026c42"/>
-                <owl:hasValue>T0 L0 M0 I0 Θ0 N0 J0</owl:hasValue>
-            </owl:Restriction>
-        </owl:equivalentClass>
-        <rdfs:subClassOf rdf:resource="http://emmo.info/emmo/middle/metrology#EMMO_9895a1b4_f0a5_4167_ac5e_97db40b8bfcc"/>
-        <rdfs:label xml:lang="en">DimensionOne</rdfs:label>
-    </owl:Class>
-    
-
-
     <!-- http://emmo.info/emmo/middle/isq#EMMO_3b931698_937e_49be_ab1b_36fa52d91181 -->
 
     <owl:Class rdf:about="http://emmo.info/emmo/middle/isq#EMMO_3b931698_937e_49be_ab1b_36fa52d91181">
@@ -1049,7 +1034,7 @@ Temperature is a relative quantity that can be used to express temperature diffe
                 <owl:allValuesFrom>
                     <owl:Restriction>
                         <owl:onProperty rdf:resource="http://emmo.info/emmo/middle/metrology#EMMO_bed1d005_b04e_4a90_94cf_02bc678a8569"/>
-                        <owl:allValuesFrom rdf:resource="http://emmo.info/emmo/middle/isq#EMMO_3227b821_26a5_4c7c_9c01_5c24483e0bd0"/>
+                        <owl:allValuesFrom rdf:resource="http://emmo.info/emmo/middle/metrology#EMMO_3227b821_26a5_4c7c_9c01_5c24483e0bd0"/>
                     </owl:Restriction>
                 </owl:allValuesFrom>
             </owl:Restriction>
@@ -1156,7 +1141,7 @@ Temperature is a relative quantity that can be used to express temperature diffe
                 <owl:allValuesFrom>
                     <owl:Restriction>
                         <owl:onProperty rdf:resource="http://emmo.info/emmo/middle/metrology#EMMO_bed1d005_b04e_4a90_94cf_02bc678a8569"/>
-                        <owl:allValuesFrom rdf:resource="http://emmo.info/emmo/middle/isq#EMMO_3227b821_26a5_4c7c_9c01_5c24483e0bd0"/>
+                        <owl:allValuesFrom rdf:resource="http://emmo.info/emmo/middle/metrology#EMMO_3227b821_26a5_4c7c_9c01_5c24483e0bd0"/>
                     </owl:Restriction>
                 </owl:allValuesFrom>
             </owl:Restriction>

--- a/middle/isq.owl
+++ b/middle/isq.owl
@@ -975,6 +975,7 @@ Temperature is a relative quantity that can be used to express temperature diffe
             </owl:Restriction>
         </rdfs:subClassOf>
         <annotations:EMMO_6dd685dd_1895_46e4_b227_be9f7d643c25>http://dbpedia.org/page/Time</annotations:EMMO_6dd685dd_1895_46e4_b227_be9f7d643c25>
+        <annotations:EMMO_70fe84ff_99b6_4206_a9fc_9a8931836d84>Time is defined as the duration of an event or more operationally as &quot;what clocks read&quot;.</annotations:EMMO_70fe84ff_99b6_4206_a9fc_9a8931836d84>
         <annotations:EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9>The indefinite continued progress of existence and events that occur in apparently irreversible succession from the past through the present to the future.</annotations:EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9>
         <annotations:EMMO_fe015383_afb3_44a6_ae86_043628697aa2>https://doi.org/10.1351/goldbook.T06375</annotations:EMMO_fe015383_afb3_44a6_ae86_043628697aa2>
         <rdfs:label xml:lang="en">Time</rdfs:label>
@@ -1157,10 +1158,11 @@ Temperature is a relative quantity that can be used to express temperature diffe
                 </owl:allValuesFrom>
             </owl:Restriction>
         </rdfs:subClassOf>
+        <annotations:EMMO_21ae69b4_235e_479d_8dd8_4f756f694c1b>Angle</annotations:EMMO_21ae69b4_235e_479d_8dd8_4f756f694c1b>
         <annotations:EMMO_6dd685dd_1895_46e4_b227_be9f7d643c25>http://dbpedia.org/page/Angle</annotations:EMMO_6dd685dd_1895_46e4_b227_be9f7d643c25>
         <annotations:EMMO_70fe84ff_99b6_4206_a9fc_9a8931836d84>Ratio of circular arc length to radius.</annotations:EMMO_70fe84ff_99b6_4206_a9fc_9a8931836d84>
         <annotations:EMMO_fe015383_afb3_44a6_ae86_043628697aa2>https://doi.org/10.1351/goldbook.A00346</annotations:EMMO_fe015383_afb3_44a6_ae86_043628697aa2>
-        <rdfs:label xml:lang="en">Angle</rdfs:label>
+        <rdfs:label xml:lang="en">PlaneAngle</rdfs:label>
     </owl:Class>
     
 

--- a/middle/isq.owl
+++ b/middle/isq.owl
@@ -1,28 +1,23 @@
 <?xml version="1.0"?>
 <rdf:RDF xmlns="http://emmo.info/emmo/middle/isq#"
      xml:base="http://emmo.info/emmo/middle/isq"
-     xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
      xmlns:owl="http://www.w3.org/2002/07/owl#"
+     xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
      xmlns:xml="http://www.w3.org/XML/1998/namespace"
      xmlns:xsd="http://www.w3.org/2001/XMLSchema#"
-     xmlns:annotations="http://emmo.info/emmo/top/annotations#"
-     xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">
+     xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+     xmlns:annotations="http://emmo.info/emmo/top/annotations#">
     <owl:Ontology rdf:about="http://emmo.info/emmo/middle/isq">
         <owl:versionIRI rdf:resource="http://emmo.info/emmo/1.0.0-alpha2/middle/isq"/>
         <owl:imports rdf:resource="http://emmo.info/emmo/1.0.0-alpha2/middle/metrology"/>
+        <annotations:EMMO_5525a055_dda5_4556_8b91_f0d22fa676cc>EMMO is released under a Creative Commons license Attribution 4.0 International (CC BY 4.0)
+
+https://creativecommons.org/licenses/by/4.0/legalcode</annotations:EMMO_5525a055_dda5_4556_8b91_f0d22fa676cc>
         <annotations:EMMO_cd5fb112_7ee7_4120_a35d_3ca3e6c3f4ab>Emanuele Ghedini (University of Bologna, IT)
 Gerhard Goldbeck (GCL Ltd, UK)
 Adham Hashibon (Fraunhofer IWM, DE)
 Georg Schmitz (Access, DE)
 Jesper Friis (SINTEF, NO)</annotations:EMMO_cd5fb112_7ee7_4120_a35d_3ca3e6c3f4ab>
-        <rdfs:comment>European Materials and Modelling Ontology (EMMO)
-
-EMMO is a multidisciplinary effort to develop a standard representational framework (the ontology) based on current materials modelling knowledge, including physical sciences, analytical philosophy and information and communication technologies.
-
-It provides the connection between the physical world, materials characterisation world and materials modelling world.</rdfs:comment>
-        <annotations:EMMO_5525a055_dda5_4556_8b91_f0d22fa676cc>EMMO is released under a Creative Commons license Attribution 4.0 International (CC BY 4.0)
-
-https://creativecommons.org/licenses/by/4.0/legalcode</annotations:EMMO_5525a055_dda5_4556_8b91_f0d22fa676cc>
         <rdfs:comment xml:lang="en">Contacts:
 Gerhard Goldbeck
 Goldbeck Consulting Ltd (UK)
@@ -31,6 +26,11 @@ email: gerhard@goldbeck-consulting.com
 Emanuele Ghedini
 University of Bologna (IT)
 email: emanuele.ghedini@unibo.it</rdfs:comment>
+        <rdfs:comment>European Materials and Modelling Ontology (EMMO)
+
+EMMO is a multidisciplinary effort to develop a standard representational framework (the ontology) based on current materials modelling knowledge, including physical sciences, analytical philosophy and information and communication technologies.
+
+It provides the connection between the physical world, materials characterisation world and materials modelling world.</rdfs:comment>
         <rdfs:comment>The EMMO requires FacT++ reasoner plugin in order to visualize all inferences and class hierarchy (ctrl+R hotkey in Protege).</rdfs:comment>
     </owl:Ontology>
     
@@ -937,6 +937,7 @@ Temperature is a relative quantity that can be used to express temperature diffe
                 </owl:allValuesFrom>
             </owl:Restriction>
         </rdfs:subClassOf>
+        <annotations:EMMO_50c298c2_55a2_4068_b3ac_4e948c33181f>http://www.electropedia.org/iev/iev.nsf/display?openform&amp;ievref=113-01-19</annotations:EMMO_50c298c2_55a2_4068_b3ac_4e948c33181f>
         <annotations:EMMO_6dd685dd_1895_46e4_b227_be9f7d643c25>http://dbpedia.org/page/Length</annotations:EMMO_6dd685dd_1895_46e4_b227_be9f7d643c25>
         <annotations:EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9>Extend of a spatial dimension.</annotations:EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9>
         <annotations:EMMO_fe015383_afb3_44a6_ae86_043628697aa2>https://doi.org/10.1351/goldbook.L03498</annotations:EMMO_fe015383_afb3_44a6_ae86_043628697aa2>
@@ -974,10 +975,12 @@ Temperature is a relative quantity that can be used to express temperature diffe
                 </owl:allValuesFrom>
             </owl:Restriction>
         </rdfs:subClassOf>
+        <annotations:EMMO_50c298c2_55a2_4068_b3ac_4e948c33181f>http://www.electropedia.org/iev/iev.nsf/display?openform&amp;ievref=113-01-03</annotations:EMMO_50c298c2_55a2_4068_b3ac_4e948c33181f>
         <annotations:EMMO_6dd685dd_1895_46e4_b227_be9f7d643c25>http://dbpedia.org/page/Time</annotations:EMMO_6dd685dd_1895_46e4_b227_be9f7d643c25>
-        <annotations:EMMO_70fe84ff_99b6_4206_a9fc_9a8931836d84>Time is defined as the duration of an event or more operationally as &quot;what clocks read&quot;.</annotations:EMMO_70fe84ff_99b6_4206_a9fc_9a8931836d84>
+        <annotations:EMMO_70fe84ff_99b6_4206_a9fc_9a8931836d84>One-dimensional subspace of space-time, which is locally orthogonal to space.</annotations:EMMO_70fe84ff_99b6_4206_a9fc_9a8931836d84>
         <annotations:EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9>The indefinite continued progress of existence and events that occur in apparently irreversible succession from the past through the present to the future.</annotations:EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9>
         <annotations:EMMO_fe015383_afb3_44a6_ae86_043628697aa2>https://doi.org/10.1351/goldbook.T06375</annotations:EMMO_fe015383_afb3_44a6_ae86_043628697aa2>
+        <rdfs:comment>Time can be seen as the duration of an event or, more operationally, as &quot;what clocks read&quot;.</rdfs:comment>
         <rdfs:label xml:lang="en">Time</rdfs:label>
     </owl:Class>
     
@@ -1208,5 +1211,5 @@ Temperature is a relative quantity that can be used to express temperature diffe
 
 
 
-<!-- Generated by the OWL API (version 4.2.8.20170104-2310) https://github.com/owlcs/owlapi -->
+<!-- Generated by the OWL API (version 4.5.9.2019-02-01T07:24:44Z) https://github.com/owlcs/owlapi -->
 

--- a/middle/metrology.owl
+++ b/middle/metrology.owl
@@ -9,10 +9,10 @@
      xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">
     <owl:Ontology rdf:about="http://emmo.info/emmo/middle/metrology">
         <owl:versionIRI rdf:resource="http://emmo.info/emmo/1.0.0-alpha2/middle/metrology"/>
-        <owl:imports rdf:resource="http://emmo.info/emmo/1.0.0-alpha2/middle/properties"/>
         <owl:imports rdf:resource="http://emmo.info/emmo/1.0.0-alpha2/middle/physicalistic"/>
-        <owl:imports rdf:resource="http://emmo.info/emmo/1.0.0-alpha2/middle/math"/>
+        <owl:imports rdf:resource="http://emmo.info/emmo/1.0.0-alpha2/middle/properties"/>
         <owl:imports rdf:resource="http://emmo.info/emmo/1.0.0-alpha2/middle/perceptual"/>
+        <owl:imports rdf:resource="http://emmo.info/emmo/1.0.0-alpha2/middle/math"/>
         <annotations:EMMO_cd5fb112_7ee7_4120_a35d_3ca3e6c3f4ab>Emanuele Ghedini (University of Bologna, IT)
 Gerhard Goldbeck (GCL Ltd, UK)
 Adham Hashibon (Fraunhofer IWM, DE)
@@ -486,6 +486,13 @@ International vocabulary of metrology (VIM)</annotations:EMMO_967080e5_2f42_4eb2
 
     <owl:Class rdf:about="http://emmo.info/emmo/middle/metrology#EMMO_b081b346_7279_46ef_9a3d_2c088fcd79f4">
         <rdfs:subClassOf rdf:resource="http://emmo.info/emmo/middle/metrology#EMMO_18ce5200_00f5_45bb_8c6f_6fb128cd41ae"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://emmo.info/emmo/middle/metrology#EMMO_bed1d005_b04e_4a90_94cf_02bc678a8569"/>
+                <owl:qualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</owl:qualifiedCardinality>
+                <owl:onClass rdf:resource="http://emmo.info/emmo/middle/metrology#EMMO_9895a1b4_f0a5_4167_ac5e_97db40b8bfcc"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <owl:disjointUnionOf rdf:parseType="Collection">
             <rdf:Description rdf:about="http://emmo.info/emmo/middle/metrology#EMMO_868ae137_4d25_493e_b270_21ea3d94849e"/>
             <rdf:Description rdf:about="http://emmo.info/emmo/middle/metrology#EMMO_c6d4a5e0_7e95_44df_a6db_84ee0a8bbc8e"/>

--- a/middle/metrology.owl
+++ b/middle/metrology.owl
@@ -1,31 +1,26 @@
 <?xml version="1.0"?>
 <rdf:RDF xmlns="http://emmo.info/emmo/middle/metrology#"
      xml:base="http://emmo.info/emmo/middle/metrology"
-     xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
      xmlns:owl="http://www.w3.org/2002/07/owl#"
+     xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
      xmlns:xml="http://www.w3.org/XML/1998/namespace"
      xmlns:xsd="http://www.w3.org/2001/XMLSchema#"
-     xmlns:annotations="http://emmo.info/emmo/top/annotations#"
-     xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">
+     xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+     xmlns:annotations="http://emmo.info/emmo/top/annotations#">
     <owl:Ontology rdf:about="http://emmo.info/emmo/middle/metrology">
         <owl:versionIRI rdf:resource="http://emmo.info/emmo/1.0.0-alpha2/middle/metrology"/>
+        <owl:imports rdf:resource="http://emmo.info/emmo/1.0.0-alpha2/middle/math"/>
+        <owl:imports rdf:resource="http://emmo.info/emmo/1.0.0-alpha2/middle/perceptual"/>
         <owl:imports rdf:resource="http://emmo.info/emmo/1.0.0-alpha2/middle/physicalistic"/>
         <owl:imports rdf:resource="http://emmo.info/emmo/1.0.0-alpha2/middle/properties"/>
-        <owl:imports rdf:resource="http://emmo.info/emmo/1.0.0-alpha2/middle/perceptual"/>
-        <owl:imports rdf:resource="http://emmo.info/emmo/1.0.0-alpha2/middle/math"/>
+        <annotations:EMMO_5525a055_dda5_4556_8b91_f0d22fa676cc>EMMO is released under a Creative Commons license Attribution 4.0 International (CC BY 4.0)
+
+https://creativecommons.org/licenses/by/4.0/legalcode</annotations:EMMO_5525a055_dda5_4556_8b91_f0d22fa676cc>
         <annotations:EMMO_cd5fb112_7ee7_4120_a35d_3ca3e6c3f4ab>Emanuele Ghedini (University of Bologna, IT)
 Gerhard Goldbeck (GCL Ltd, UK)
 Adham Hashibon (Fraunhofer IWM, DE)
 Georg Schmitz (Access, DE)
 Jesper Friis (SINTEF, NO)</annotations:EMMO_cd5fb112_7ee7_4120_a35d_3ca3e6c3f4ab>
-        <rdfs:comment>European Materials and Modelling Ontology (EMMO)
-
-EMMO is a multidisciplinary effort to develop a standard representational framework (the ontology) based on current materials modelling knowledge, including physical sciences, analytical philosophy and information and communication technologies.
-
-It provides the connection between the physical world, materials characterisation world and materials modelling world.</rdfs:comment>
-        <annotations:EMMO_5525a055_dda5_4556_8b91_f0d22fa676cc>EMMO is released under a Creative Commons license Attribution 4.0 International (CC BY 4.0)
-
-https://creativecommons.org/licenses/by/4.0/legalcode</annotations:EMMO_5525a055_dda5_4556_8b91_f0d22fa676cc>
         <rdfs:comment xml:lang="en">Contacts:
 Gerhard Goldbeck
 Goldbeck Consulting Ltd (UK)
@@ -34,6 +29,11 @@ email: gerhard@goldbeck-consulting.com
 Emanuele Ghedini
 University of Bologna (IT)
 email: emanuele.ghedini@unibo.it</rdfs:comment>
+        <rdfs:comment>European Materials and Modelling Ontology (EMMO)
+
+EMMO is a multidisciplinary effort to develop a standard representational framework (the ontology) based on current materials modelling knowledge, including physical sciences, analytical philosophy and information and communication technologies.
+
+It provides the connection between the physical world, materials characterisation world and materials modelling world.</rdfs:comment>
         <rdfs:comment>The EMMO requires FacT++ reasoner plugin in order to visualize all inferences and class hierarchy (ctrl+R hotkey in Protege).</rdfs:comment>
     </owl:Ontology>
     
@@ -98,6 +98,21 @@ email: emanuele.ghedini@unibo.it</rdfs:comment>
     ///////////////////////////////////////////////////////////////////////////////////////
      -->
 
+    
+
+
+    <!-- http://emmo.info/emmo/middle/metrology#EMMO_3227b821_26a5_4c7c_9c01_5c24483e0bd0 -->
+
+    <owl:Class rdf:about="http://emmo.info/emmo/middle/metrology#EMMO_3227b821_26a5_4c7c_9c01_5c24483e0bd0">
+        <owl:equivalentClass>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://emmo.info/emmo/middle/perceptual#EMMO_23b579e1_8088_45b5_9975_064014026c42"/>
+                <owl:hasValue>T0 L0 M0 I0 Θ0 N0 J0</owl:hasValue>
+            </owl:Restriction>
+        </owl:equivalentClass>
+        <rdfs:subClassOf rdf:resource="http://emmo.info/emmo/middle/metrology#EMMO_9895a1b4_f0a5_4167_ac5e_97db40b8bfcc"/>
+        <rdfs:label xml:lang="en">DimensionOne</rdfs:label>
+    </owl:Class>
     
 
 
@@ -311,6 +326,12 @@ barn</annotations:EMMO_b432d2d5_25f4_4165_99c5_5935a7763c1a>
 
     <owl:Class rdf:about="http://emmo.info/emmo/middle/metrology#EMMO_5ebd5e01_0ed3_49a2_a30d_cd05cbe72978">
         <rdfs:subClassOf rdf:resource="http://emmo.info/emmo/middle/metrology#EMMO_db716151_6b73_45ff_910c_d182fdcbb4f5"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://emmo.info/emmo/middle/metrology#EMMO_bed1d005_b04e_4a90_94cf_02bc678a8569"/>
+                <owl:allValuesFrom rdf:resource="http://emmo.info/emmo/middle/metrology#EMMO_3227b821_26a5_4c7c_9c01_5c24483e0bd0"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <annotations:EMMO_1f1b164d_ec6a_4faa_8d5e_88bda62316cc>http://qudt.org/vocab/unit/UNITLESS</annotations:EMMO_1f1b164d_ec6a_4faa_8d5e_88bda62316cc>
         <annotations:EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9>Represents the number 1, used as an explicit unit to say something has no units.</annotations:EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9>
         <annotations:EMMO_b432d2d5_25f4_4165_99c5_5935a7763c1a>Refractive index or volume fraction.</annotations:EMMO_b432d2d5_25f4_4165_99c5_5935a7763c1a>
@@ -705,5 +726,5 @@ While the string &quot;1 kg&quot; is a &apos;Physical Quantity&apos;.</rdfs:comm
 
 
 
-<!-- Generated by the OWL API (version 4.2.8.20170104-2310) https://github.com/owlcs/owlapi -->
+<!-- Generated by the OWL API (version 4.5.9.2019-02-01T07:24:44Z) https://github.com/owlcs/owlapi -->
 

--- a/middle/siunits.owl
+++ b/middle/siunits.owl
@@ -49,13 +49,26 @@ email: emanuele.ghedini@unibo.it</rdfs:comment>
     
 
 
+    <!-- http://emmo.info/emmo/middle/metrology#EMMO_5ebd5e01_0ed3_49a2_a30d_cd05cbe72978 -->
+
+    <rdf:Description rdf:about="http://emmo.info/emmo/middle/metrology#EMMO_5ebd5e01_0ed3_49a2_a30d_cd05cbe72978">
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://emmo.info/emmo/middle/metrology#EMMO_bed1d005_b04e_4a90_94cf_02bc678a8569"/>
+                <owl:allValuesFrom rdf:resource="http://emmo.info/emmo/middle/isq#EMMO_3227b821_26a5_4c7c_9c01_5c24483e0bd0"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+    </rdf:Description>
+    
+
+
     <!-- http://emmo.info/emmo/middle/siunits#EMMO_00199e76_69dc_45b6_a9c6_98cc90cdc0f5 -->
 
     <owl:Class rdf:about="http://emmo.info/emmo/middle/siunits#EMMO_00199e76_69dc_45b6_a9c6_98cc90cdc0f5">
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://emmo.info/emmo/middle/metrology#EMMO_bed1d005_b04e_4a90_94cf_02bc678a8569"/>
-                <owl:someValuesFrom rdf:resource="http://emmo.info/emmo/middle/isq#EMMO_847f1d9f_205e_46c1_8cb6_a9e479421f88"/>
+                <owl:allValuesFrom rdf:resource="http://emmo.info/emmo/middle/isq#EMMO_847f1d9f_205e_46c1_8cb6_a9e479421f88"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <rdfs:subClassOf>
@@ -107,7 +120,7 @@ email: emanuele.ghedini@unibo.it</rdfs:comment>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://emmo.info/emmo/middle/metrology#EMMO_bed1d005_b04e_4a90_94cf_02bc678a8569"/>
-                <owl:someValuesFrom rdf:resource="http://emmo.info/emmo/middle/isq#EMMO_c8d084ad_f88e_4596_8e4d_982c6655ce6f"/>
+                <owl:allValuesFrom rdf:resource="http://emmo.info/emmo/middle/isq#EMMO_c8d084ad_f88e_4596_8e4d_982c6655ce6f"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <rdfs:subClassOf>
@@ -311,7 +324,7 @@ kg/m^3</annotations:EMMO_b432d2d5_25f4_4165_99c5_5935a7763c1a>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://emmo.info/emmo/middle/metrology#EMMO_bed1d005_b04e_4a90_94cf_02bc678a8569"/>
-                <owl:someValuesFrom rdf:resource="http://emmo.info/emmo/middle/isq#EMMO_a77a0a4b_6bd2_42b2_be27_4b63cebbb59e"/>
+                <owl:allValuesFrom rdf:resource="http://emmo.info/emmo/middle/isq#EMMO_a77a0a4b_6bd2_42b2_be27_4b63cebbb59e"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <rdfs:subClassOf>
@@ -334,7 +347,7 @@ kg/m^3</annotations:EMMO_b432d2d5_25f4_4165_99c5_5935a7763c1a>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://emmo.info/emmo/middle/metrology#EMMO_bed1d005_b04e_4a90_94cf_02bc678a8569"/>
-                <owl:someValuesFrom rdf:resource="http://emmo.info/emmo/middle/isq#EMMO_02e894c3_b793_4197_b120_3442e08f58d1"/>
+                <owl:allValuesFrom rdf:resource="http://emmo.info/emmo/middle/isq#EMMO_02e894c3_b793_4197_b120_3442e08f58d1"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <rdfs:subClassOf>
@@ -369,7 +382,7 @@ kg/m^3</annotations:EMMO_b432d2d5_25f4_4165_99c5_5935a7763c1a>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://emmo.info/emmo/middle/metrology#EMMO_bed1d005_b04e_4a90_94cf_02bc678a8569"/>
-                <owl:someValuesFrom rdf:resource="http://emmo.info/emmo/middle/isq#EMMO_ce7d4720_aa20_4a8c_93e8_df41a35b6723"/>
+                <owl:allValuesFrom rdf:resource="http://emmo.info/emmo/middle/isq#EMMO_ce7d4720_aa20_4a8c_93e8_df41a35b6723"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <rdfs:subClassOf>
@@ -564,7 +577,7 @@ kg/m^3</annotations:EMMO_b432d2d5_25f4_4165_99c5_5935a7763c1a>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://emmo.info/emmo/middle/metrology#EMMO_bed1d005_b04e_4a90_94cf_02bc678a8569"/>
-                <owl:someValuesFrom rdf:resource="http://emmo.info/emmo/middle/isq#EMMO_7610efb8_c7c6_4684_abc1_774783c62472"/>
+                <owl:allValuesFrom rdf:resource="http://emmo.info/emmo/middle/isq#EMMO_7610efb8_c7c6_4684_abc1_774783c62472"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <rdfs:subClassOf>
@@ -654,7 +667,7 @@ kg/m^3</annotations:EMMO_b432d2d5_25f4_4165_99c5_5935a7763c1a>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://emmo.info/emmo/middle/metrology#EMMO_bed1d005_b04e_4a90_94cf_02bc678a8569"/>
-                <owl:someValuesFrom rdf:resource="http://emmo.info/emmo/middle/isq#EMMO_ab79e92b_5377_454d_be06_d61b50db295a"/>
+                <owl:allValuesFrom rdf:resource="http://emmo.info/emmo/middle/isq#EMMO_ab79e92b_5377_454d_be06_d61b50db295a"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <rdfs:subClassOf>
@@ -743,7 +756,7 @@ kg/m^3</annotations:EMMO_b432d2d5_25f4_4165_99c5_5935a7763c1a>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://emmo.info/emmo/middle/metrology#EMMO_bed1d005_b04e_4a90_94cf_02bc678a8569"/>
-                <owl:someValuesFrom rdf:resource="http://emmo.info/emmo/middle/isq#EMMO_b3600e73_3e05_479d_9714_c041c3acf5cc"/>
+                <owl:allValuesFrom rdf:resource="http://emmo.info/emmo/middle/isq#EMMO_b3600e73_3e05_479d_9714_c041c3acf5cc"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <rdfs:subClassOf>
@@ -778,7 +791,7 @@ kg/m^3</annotations:EMMO_b432d2d5_25f4_4165_99c5_5935a7763c1a>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://emmo.info/emmo/middle/metrology#EMMO_bed1d005_b04e_4a90_94cf_02bc678a8569"/>
-                <owl:someValuesFrom rdf:resource="http://emmo.info/emmo/middle/isq#EMMO_f6070071_d054_4b17_9d2d_f446f7147d0f"/>
+                <owl:allValuesFrom rdf:resource="http://emmo.info/emmo/middle/isq#EMMO_f6070071_d054_4b17_9d2d_f446f7147d0f"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <rdfs:subClassOf>
@@ -801,7 +814,7 @@ kg/m^3</annotations:EMMO_b432d2d5_25f4_4165_99c5_5935a7763c1a>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://emmo.info/emmo/middle/metrology#EMMO_bed1d005_b04e_4a90_94cf_02bc678a8569"/>
-                <owl:someValuesFrom rdf:resource="http://emmo.info/emmo/middle/isq#EMMO_14ff4393_0f28_4fb4_abc7_c2cc00bc761d"/>
+                <owl:allValuesFrom rdf:resource="http://emmo.info/emmo/middle/isq#EMMO_14ff4393_0f28_4fb4_abc7_c2cc00bc761d"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <rdfs:subClassOf>
@@ -847,7 +860,7 @@ kg/m^3</annotations:EMMO_b432d2d5_25f4_4165_99c5_5935a7763c1a>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://emmo.info/emmo/middle/metrology#EMMO_bed1d005_b04e_4a90_94cf_02bc678a8569"/>
-                <owl:someValuesFrom rdf:resource="http://emmo.info/emmo/middle/isq#EMMO_77e9dc31_5b19_463e_b000_44c6e79f98aa"/>
+                <owl:allValuesFrom rdf:resource="http://emmo.info/emmo/middle/isq#EMMO_77e9dc31_5b19_463e_b000_44c6e79f98aa"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <rdfs:subClassOf>
@@ -899,7 +912,7 @@ kg/m^3</annotations:EMMO_b432d2d5_25f4_4165_99c5_5935a7763c1a>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://emmo.info/emmo/middle/metrology#EMMO_bed1d005_b04e_4a90_94cf_02bc678a8569"/>
-                <owl:someValuesFrom rdf:resource="http://emmo.info/emmo/middle/isq#EMMO_3227b821_26a5_4c7c_9c01_5c24483e0bd0"/>
+                <owl:allValuesFrom rdf:resource="http://emmo.info/emmo/middle/isq#EMMO_3227b821_26a5_4c7c_9c01_5c24483e0bd0"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <rdfs:subClassOf>
@@ -952,7 +965,7 @@ kg/m^3</annotations:EMMO_b432d2d5_25f4_4165_99c5_5935a7763c1a>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://emmo.info/emmo/middle/metrology#EMMO_bed1d005_b04e_4a90_94cf_02bc678a8569"/>
-                <owl:someValuesFrom rdf:resource="http://emmo.info/emmo/middle/isq#EMMO_53bd0c90_41c3_46e2_8779_cd2a80f7e18b"/>
+                <owl:allValuesFrom rdf:resource="http://emmo.info/emmo/middle/isq#EMMO_53bd0c90_41c3_46e2_8779_cd2a80f7e18b"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <rdfs:subClassOf>
@@ -1004,7 +1017,7 @@ kg/m^3</annotations:EMMO_b432d2d5_25f4_4165_99c5_5935a7763c1a>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://emmo.info/emmo/middle/metrology#EMMO_bed1d005_b04e_4a90_94cf_02bc678a8569"/>
-                <owl:someValuesFrom rdf:resource="http://emmo.info/emmo/middle/isq#EMMO_b14d9be5_f81e_469b_abca_379c2e83feab"/>
+                <owl:allValuesFrom rdf:resource="http://emmo.info/emmo/middle/isq#EMMO_b14d9be5_f81e_469b_abca_379c2e83feab"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <rdfs:subClassOf>
@@ -1027,7 +1040,7 @@ kg/m^3</annotations:EMMO_b432d2d5_25f4_4165_99c5_5935a7763c1a>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://emmo.info/emmo/middle/metrology#EMMO_bed1d005_b04e_4a90_94cf_02bc678a8569"/>
-                <owl:someValuesFrom rdf:resource="http://emmo.info/emmo/middle/isq#EMMO_53e825d9_1a09_483c_baa7_37501ebfbe1c"/>
+                <owl:allValuesFrom rdf:resource="http://emmo.info/emmo/middle/isq#EMMO_53e825d9_1a09_483c_baa7_37501ebfbe1c"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <rdfs:subClassOf>
@@ -1050,7 +1063,7 @@ kg/m^3</annotations:EMMO_b432d2d5_25f4_4165_99c5_5935a7763c1a>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://emmo.info/emmo/middle/metrology#EMMO_bed1d005_b04e_4a90_94cf_02bc678a8569"/>
-                <owl:someValuesFrom rdf:resource="http://emmo.info/emmo/middle/isq#EMMO_ec903946_ddc9_464a_903c_7373e0d1eeb5"/>
+                <owl:allValuesFrom rdf:resource="http://emmo.info/emmo/middle/isq#EMMO_ec903946_ddc9_464a_903c_7373e0d1eeb5"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <rdfs:subClassOf>
@@ -1073,7 +1086,7 @@ kg/m^3</annotations:EMMO_b432d2d5_25f4_4165_99c5_5935a7763c1a>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://emmo.info/emmo/middle/metrology#EMMO_bed1d005_b04e_4a90_94cf_02bc678a8569"/>
-                <owl:someValuesFrom rdf:resource="http://emmo.info/emmo/middle/isq#EMMO_a77a0a4b_6bd2_42b2_be27_4b63cebbb59e"/>
+                <owl:allValuesFrom rdf:resource="http://emmo.info/emmo/middle/isq#EMMO_a77a0a4b_6bd2_42b2_be27_4b63cebbb59e"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <rdfs:subClassOf>
@@ -1125,7 +1138,7 @@ kg/m^3</annotations:EMMO_b432d2d5_25f4_4165_99c5_5935a7763c1a>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://emmo.info/emmo/middle/metrology#EMMO_bed1d005_b04e_4a90_94cf_02bc678a8569"/>
-                <owl:someValuesFrom rdf:resource="http://emmo.info/emmo/middle/isq#EMMO_515b5579_d526_4842_9e6f_ecc34db6f368"/>
+                <owl:allValuesFrom rdf:resource="http://emmo.info/emmo/middle/isq#EMMO_515b5579_d526_4842_9e6f_ecc34db6f368"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <rdfs:subClassOf>
@@ -1149,7 +1162,7 @@ kg/m^3</annotations:EMMO_b432d2d5_25f4_4165_99c5_5935a7763c1a>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://emmo.info/emmo/middle/metrology#EMMO_bed1d005_b04e_4a90_94cf_02bc678a8569"/>
-                <owl:someValuesFrom rdf:resource="http://emmo.info/emmo/middle/isq#EMMO_3227b821_26a5_4c7c_9c01_5c24483e0bd0"/>
+                <owl:allValuesFrom rdf:resource="http://emmo.info/emmo/middle/isq#EMMO_3227b821_26a5_4c7c_9c01_5c24483e0bd0"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <rdfs:subClassOf>
@@ -1190,7 +1203,7 @@ kg/m^3</annotations:EMMO_b432d2d5_25f4_4165_99c5_5935a7763c1a>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://emmo.info/emmo/middle/metrology#EMMO_bed1d005_b04e_4a90_94cf_02bc678a8569"/>
-                <owl:someValuesFrom rdf:resource="http://emmo.info/emmo/middle/isq#EMMO_14ff4393_0f28_4fb4_abc7_c2cc00bc761d"/>
+                <owl:allValuesFrom rdf:resource="http://emmo.info/emmo/middle/isq#EMMO_14ff4393_0f28_4fb4_abc7_c2cc00bc761d"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <rdfs:subClassOf>
@@ -1213,7 +1226,7 @@ kg/m^3</annotations:EMMO_b432d2d5_25f4_4165_99c5_5935a7763c1a>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://emmo.info/emmo/middle/metrology#EMMO_bed1d005_b04e_4a90_94cf_02bc678a8569"/>
-                <owl:someValuesFrom rdf:resource="http://emmo.info/emmo/middle/isq#EMMO_4c49ab58_a6f6_409e_b849_f873ae1dcbee"/>
+                <owl:allValuesFrom rdf:resource="http://emmo.info/emmo/middle/isq#EMMO_4c49ab58_a6f6_409e_b849_f873ae1dcbee"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <rdfs:subClassOf>
@@ -1236,7 +1249,7 @@ kg/m^3</annotations:EMMO_b432d2d5_25f4_4165_99c5_5935a7763c1a>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://emmo.info/emmo/middle/metrology#EMMO_bed1d005_b04e_4a90_94cf_02bc678a8569"/>
-                <owl:someValuesFrom rdf:resource="http://emmo.info/emmo/middle/isq#EMMO_668e6ead_1530_40cc_ad5e_24b880edff50"/>
+                <owl:allValuesFrom rdf:resource="http://emmo.info/emmo/middle/isq#EMMO_668e6ead_1530_40cc_ad5e_24b880edff50"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <rdfs:subClassOf>
@@ -1288,7 +1301,7 @@ kg/m^3</annotations:EMMO_b432d2d5_25f4_4165_99c5_5935a7763c1a>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://emmo.info/emmo/middle/metrology#EMMO_bed1d005_b04e_4a90_94cf_02bc678a8569"/>
-                <owl:someValuesFrom rdf:resource="http://emmo.info/emmo/middle/isq#EMMO_d5f3e0e5_fc7d_4e64_86ad_555e74aaff84"/>
+                <owl:allValuesFrom rdf:resource="http://emmo.info/emmo/middle/isq#EMMO_d5f3e0e5_fc7d_4e64_86ad_555e74aaff84"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <rdfs:subClassOf>
@@ -1311,7 +1324,7 @@ kg/m^3</annotations:EMMO_b432d2d5_25f4_4165_99c5_5935a7763c1a>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://emmo.info/emmo/middle/metrology#EMMO_bed1d005_b04e_4a90_94cf_02bc678a8569"/>
-                <owl:someValuesFrom rdf:resource="http://emmo.info/emmo/middle/isq#EMMO_847f1d9f_205e_46c1_8cb6_a9e479421f88"/>
+                <owl:allValuesFrom rdf:resource="http://emmo.info/emmo/middle/isq#EMMO_847f1d9f_205e_46c1_8cb6_a9e479421f88"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <rdfs:subClassOf>
@@ -1337,7 +1350,7 @@ Sievert is derived from absorbed dose, but takes into account the biological eff
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://emmo.info/emmo/middle/metrology#EMMO_bed1d005_b04e_4a90_94cf_02bc678a8569"/>
-                <owl:someValuesFrom rdf:resource="http://emmo.info/emmo/middle/isq#EMMO_e501069c_34d3_4dc7_ac87_c90c7342192b"/>
+                <owl:allValuesFrom rdf:resource="http://emmo.info/emmo/middle/isq#EMMO_e501069c_34d3_4dc7_ac87_c90c7342192b"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <rdfs:subClassOf>
@@ -1389,7 +1402,7 @@ Sievert is derived from absorbed dose, but takes into account the biological eff
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://emmo.info/emmo/middle/metrology#EMMO_bed1d005_b04e_4a90_94cf_02bc678a8569"/>
-                <owl:someValuesFrom rdf:resource="http://emmo.info/emmo/middle/isq#EMMO_2e7e5796_4a80_4d73_bb84_f31138446c0c"/>
+                <owl:allValuesFrom rdf:resource="http://emmo.info/emmo/middle/isq#EMMO_2e7e5796_4a80_4d73_bb84_f31138446c0c"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <rdfs:subClassOf>
@@ -1412,7 +1425,7 @@ Sievert is derived from absorbed dose, but takes into account the biological eff
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://emmo.info/emmo/middle/metrology#EMMO_bed1d005_b04e_4a90_94cf_02bc678a8569"/>
-                <owl:someValuesFrom rdf:resource="http://emmo.info/emmo/middle/isq#EMMO_515b5579_d526_4842_9e6f_ecc34db6f368"/>
+                <owl:allValuesFrom rdf:resource="http://emmo.info/emmo/middle/isq#EMMO_515b5579_d526_4842_9e6f_ecc34db6f368"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <rdfs:subClassOf>
@@ -1500,7 +1513,7 @@ Sievert is derived from absorbed dose, but takes into account the biological eff
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://emmo.info/emmo/middle/metrology#EMMO_bed1d005_b04e_4a90_94cf_02bc678a8569"/>
-                <owl:someValuesFrom rdf:resource="http://emmo.info/emmo/middle/isq#EMMO_321af35f_f0cc_4a5c_b4fe_8c2c0303fb0c"/>
+                <owl:allValuesFrom rdf:resource="http://emmo.info/emmo/middle/isq#EMMO_321af35f_f0cc_4a5c_b4fe_8c2c0303fb0c"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <rdfs:subClassOf>
@@ -1579,7 +1592,7 @@ Sievert is derived from absorbed dose, but takes into account the biological eff
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://emmo.info/emmo/middle/metrology#EMMO_bed1d005_b04e_4a90_94cf_02bc678a8569"/>
-                <owl:someValuesFrom rdf:resource="http://emmo.info/emmo/middle/isq#EMMO_585e0ff0_9429_4d3c_b578_58abb1ba21d1"/>
+                <owl:allValuesFrom rdf:resource="http://emmo.info/emmo/middle/isq#EMMO_585e0ff0_9429_4d3c_b578_58abb1ba21d1"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <rdfs:subClassOf>

--- a/middle/siunits.owl
+++ b/middle/siunits.owl
@@ -49,19 +49,6 @@ It provides the connection between the physical world, materials characterisatio
     
 
 
-    <!-- http://emmo.info/emmo/middle/metrology#EMMO_5ebd5e01_0ed3_49a2_a30d_cd05cbe72978 -->
-
-    <rdf:Description rdf:about="http://emmo.info/emmo/middle/metrology#EMMO_5ebd5e01_0ed3_49a2_a30d_cd05cbe72978">
-        <rdfs:subClassOf>
-            <owl:Restriction>
-                <owl:onProperty rdf:resource="http://emmo.info/emmo/middle/metrology#EMMO_bed1d005_b04e_4a90_94cf_02bc678a8569"/>
-                <owl:allValuesFrom rdf:resource="http://emmo.info/emmo/middle/isq#EMMO_3227b821_26a5_4c7c_9c01_5c24483e0bd0"/>
-            </owl:Restriction>
-        </rdfs:subClassOf>
-    </rdf:Description>
-    
-
-
     <!-- http://emmo.info/emmo/middle/siunits#EMMO_00199e76_69dc_45b6_a9c6_98cc90cdc0f5 -->
 
     <owl:Class rdf:about="http://emmo.info/emmo/middle/siunits#EMMO_00199e76_69dc_45b6_a9c6_98cc90cdc0f5">
@@ -917,7 +904,7 @@ kg/m^3</annotations:EMMO_b432d2d5_25f4_4165_99c5_5935a7763c1a>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://emmo.info/emmo/middle/metrology#EMMO_bed1d005_b04e_4a90_94cf_02bc678a8569"/>
-                <owl:allValuesFrom rdf:resource="http://emmo.info/emmo/middle/isq#EMMO_3227b821_26a5_4c7c_9c01_5c24483e0bd0"/>
+                <owl:allValuesFrom rdf:resource="http://emmo.info/emmo/middle/metrology#EMMO_3227b821_26a5_4c7c_9c01_5c24483e0bd0"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <rdfs:subClassOf>
@@ -1167,7 +1154,7 @@ kg/m^3</annotations:EMMO_b432d2d5_25f4_4165_99c5_5935a7763c1a>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://emmo.info/emmo/middle/metrology#EMMO_bed1d005_b04e_4a90_94cf_02bc678a8569"/>
-                <owl:allValuesFrom rdf:resource="http://emmo.info/emmo/middle/isq#EMMO_3227b821_26a5_4c7c_9c01_5c24483e0bd0"/>
+                <owl:allValuesFrom rdf:resource="http://emmo.info/emmo/middle/metrology#EMMO_3227b821_26a5_4c7c_9c01_5c24483e0bd0"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <rdfs:subClassOf>

--- a/middle/siunits.owl
+++ b/middle/siunits.owl
@@ -1,30 +1,25 @@
 <?xml version="1.0"?>
 <rdf:RDF xmlns="http://emmo.info/emmo/middle/siunits#"
      xml:base="http://emmo.info/emmo/middle/siunits"
-     xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
      xmlns:owl="http://www.w3.org/2002/07/owl#"
+     xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
      xmlns:xml="http://www.w3.org/XML/1998/namespace"
-     xmlns:graphical="http://emmo.info/emmo/middle/perceptual#"
-     xmlns:changes="http://emmo.info/emmo/middle/changes#"
      xmlns:xsd="http://www.w3.org/2001/XMLSchema#"
-     xmlns:annotations="http://emmo.info/emmo/top/annotations#"
-     xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">
+     xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+     xmlns:changes="http://emmo.info/emmo/middle/changes#"
+     xmlns:graphical="http://emmo.info/emmo/middle/perceptual#"
+     xmlns:annotations="http://emmo.info/emmo/top/annotations#">
     <owl:Ontology rdf:about="http://emmo.info/emmo/middle/siunits">
         <owl:versionIRI rdf:resource="http://emmo.info/emmo/1.0.0-alpha2/middle/siunits"/>
         <owl:imports rdf:resource="http://emmo.info/emmo/1.0.0-alpha2/middle/isq"/>
+        <annotations:EMMO_5525a055_dda5_4556_8b91_f0d22fa676cc>EMMO is released under a Creative Commons license Attribution 4.0 International (CC BY 4.0)
+
+https://creativecommons.org/licenses/by/4.0/legalcode</annotations:EMMO_5525a055_dda5_4556_8b91_f0d22fa676cc>
         <annotations:EMMO_cd5fb112_7ee7_4120_a35d_3ca3e6c3f4ab>Emanuele Ghedini (University of Bologna, IT)
 Gerhard Goldbeck (GCL Ltd, UK)
 Adham Hashibon (Fraunhofer IWM, DE)
 Georg Schmitz (Access, DE)
 Jesper Friis (SINTEF, NO)</annotations:EMMO_cd5fb112_7ee7_4120_a35d_3ca3e6c3f4ab>
-        <rdfs:comment>European Materials and Modelling Ontology (EMMO)
-
-EMMO is a multidisciplinary effort to develop a standard representational framework (the ontology) based on current materials modelling knowledge, including physical sciences, analytical philosophy and information and communication technologies.
-
-It provides the connection between the physical world, materials characterisation world and materials modelling world.</rdfs:comment>
-        <annotations:EMMO_5525a055_dda5_4556_8b91_f0d22fa676cc>EMMO is released under a Creative Commons license Attribution 4.0 International (CC BY 4.0)
-
-https://creativecommons.org/licenses/by/4.0/legalcode</annotations:EMMO_5525a055_dda5_4556_8b91_f0d22fa676cc>
         <rdfs:comment xml:lang="en">Contacts:
 Gerhard Goldbeck
 Goldbeck Consulting Ltd (UK)
@@ -33,6 +28,11 @@ email: gerhard@goldbeck-consulting.com
 Emanuele Ghedini
 University of Bologna (IT)
 email: emanuele.ghedini@unibo.it</rdfs:comment>
+        <rdfs:comment>European Materials and Modelling Ontology (EMMO)
+
+EMMO is a multidisciplinary effort to develop a standard representational framework (the ontology) based on current materials modelling knowledge, including physical sciences, analytical philosophy and information and communication technologies.
+
+It provides the connection between the physical world, materials characterisation world and materials modelling world.</rdfs:comment>
         <rdfs:comment>The EMMO requires FacT++ reasoner plugin in order to visualize all inferences and class hierarchy (ctrl+R hotkey in Protege).</rdfs:comment>
     </owl:Ontology>
     
@@ -181,6 +181,7 @@ kg/m^3</annotations:EMMO_b432d2d5_25f4_4165_99c5_5935a7763c1a>
     <!-- http://emmo.info/emmo/middle/siunits#EMMO_176cae33_b83e_4cd2_a6bc_281f42f0ccc8 -->
 
     <owl:Class rdf:about="http://emmo.info/emmo/middle/siunits#EMMO_176cae33_b83e_4cd2_a6bc_281f42f0ccc8">
+        <rdfs:subClassOf rdf:resource="http://emmo.info/emmo/middle/siunits#EMMO_f2ca6dd0_0e5f_4392_a92d_cafdae6cfc95"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://emmo.info/emmo/middle/metrology#EMMO_67fc0a36_8dcb_4ffa_9a43_31074efa3296"/>
@@ -540,6 +541,7 @@ kg/m^3</annotations:EMMO_b432d2d5_25f4_4165_99c5_5935a7763c1a>
     <!-- http://emmo.info/emmo/middle/siunits#EMMO_506f7823_52bc_40cb_be07_b3b1e10cce13 -->
 
     <owl:Class rdf:about="http://emmo.info/emmo/middle/siunits#EMMO_506f7823_52bc_40cb_be07_b3b1e10cce13">
+        <rdfs:subClassOf rdf:resource="http://emmo.info/emmo/middle/siunits#EMMO_f2ca6dd0_0e5f_4392_a92d_cafdae6cfc95"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://emmo.info/emmo/middle/metrology#EMMO_67fc0a36_8dcb_4ffa_9a43_31074efa3296"/>
@@ -561,6 +563,7 @@ kg/m^3</annotations:EMMO_b432d2d5_25f4_4165_99c5_5935a7763c1a>
 
     <owl:Class rdf:about="http://emmo.info/emmo/middle/siunits#EMMO_58a650f0_a638_4743_8439_535a325e5c4c">
         <rdfs:subClassOf rdf:resource="http://emmo.info/emmo/middle/isq#EMMO_1604f495_328a_4f28_9962_f4cc210739dd"/>
+        <rdfs:subClassOf rdf:resource="http://emmo.info/emmo/middle/siunits#EMMO_f2ca6dd0_0e5f_4392_a92d_cafdae6cfc95"/>
         <annotations:EMMO_1f1b164d_ec6a_4faa_8d5e_88bda62316cc>http://physics.nist.gov/cuu/CODATA-Value_ElementaryCharge</annotations:EMMO_1f1b164d_ec6a_4faa_8d5e_88bda62316cc>
         <annotations:EMMO_6dd685dd_1895_46e4_b227_be9f7d643c25>http://dbpedia.org/page/Elementary_charge</annotations:EMMO_6dd685dd_1895_46e4_b227_be9f7d643c25>
         <annotations:EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9>The magnitude of the electric charge carried by a single electron.</annotations:EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9>
@@ -730,6 +733,7 @@ kg/m^3</annotations:EMMO_b432d2d5_25f4_4165_99c5_5935a7763c1a>
     <!-- http://emmo.info/emmo/middle/siunits#EMMO_76cc4efc_231e_42b4_be83_2547681caed6 -->
 
     <owl:Class rdf:about="http://emmo.info/emmo/middle/siunits#EMMO_76cc4efc_231e_42b4_be83_2547681caed6">
+        <rdfs:subClassOf rdf:resource="http://emmo.info/emmo/middle/siunits#EMMO_f2ca6dd0_0e5f_4392_a92d_cafdae6cfc95"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://emmo.info/emmo/middle/metrology#EMMO_67fc0a36_8dcb_4ffa_9a43_31074efa3296"/>
@@ -834,6 +838,7 @@ kg/m^3</annotations:EMMO_b432d2d5_25f4_4165_99c5_5935a7763c1a>
     <!-- http://emmo.info/emmo/middle/siunits#EMMO_99296e55_53f7_4333_9e06_760ad175a1b9 -->
 
     <owl:Class rdf:about="http://emmo.info/emmo/middle/siunits#EMMO_99296e55_53f7_4333_9e06_760ad175a1b9">
+        <rdfs:subClassOf rdf:resource="http://emmo.info/emmo/middle/siunits#EMMO_f2ca6dd0_0e5f_4392_a92d_cafdae6cfc95"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://emmo.info/emmo/middle/metrology#EMMO_67fc0a36_8dcb_4ffa_9a43_31074efa3296"/>
@@ -1183,13 +1188,6 @@ kg/m^3</annotations:EMMO_b432d2d5_25f4_4165_99c5_5935a7763c1a>
 
     <owl:Class rdf:about="http://emmo.info/emmo/middle/siunits#EMMO_d41ce84b_4317_41fb_a5d1_6cd281fca106">
         <rdfs:subClassOf rdf:resource="http://emmo.info/emmo/middle/metrology#EMMO_c6d4a5e0_7e95_44df_a6db_84ee0a8bbc8e"/>
-        <rdfs:subClassOf>
-            <owl:Restriction>
-                <owl:onProperty rdf:resource="http://emmo.info/emmo/middle/reductionistic#EMMO_b2282816_b7a3_44c6_b2cb_3feff1ceb7fe"/>
-                <owl:qualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</owl:qualifiedCardinality>
-                <owl:onClass rdf:resource="http://emmo.info/emmo/middle/siunits#EMMO_32129fb5_df25_48fd_a29c_18a2f22a2dd5"/>
-            </owl:Restriction>
-        </rdfs:subClassOf>
         <annotations:EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9>A SI base or special unit with a metric prefix.</annotations:EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9>
         <rdfs:comment>The presence of the prefix makes this units non-coherent with SI system.</rdfs:comment>
         <rdfs:label xml:lang="en">SIPrefixedUnit</rdfs:label>
@@ -1532,15 +1530,6 @@ Sievert is derived from absorbed dose, but takes into account the biological eff
 
     <owl:Class rdf:about="http://emmo.info/emmo/middle/siunits#EMMO_f2ca6dd0_0e5f_4392_a92d_cafdae6cfc95">
         <rdfs:subClassOf rdf:resource="http://emmo.info/emmo/middle/metrology#EMMO_89762966_8076_4f7c_b745_f718d653e8e2"/>
-        <owl:disjointUnionOf rdf:parseType="Collection">
-            <rdf:Description rdf:about="http://emmo.info/emmo/middle/siunits#EMMO_176cae33_b83e_4cd2_a6bc_281f42f0ccc8"/>
-            <rdf:Description rdf:about="http://emmo.info/emmo/middle/siunits#EMMO_506f7823_52bc_40cb_be07_b3b1e10cce13"/>
-            <rdf:Description rdf:about="http://emmo.info/emmo/middle/siunits#EMMO_58a650f0_a638_4743_8439_535a325e5c4c"/>
-            <rdf:Description rdf:about="http://emmo.info/emmo/middle/siunits#EMMO_76cc4efc_231e_42b4_be83_2547681caed6"/>
-            <rdf:Description rdf:about="http://emmo.info/emmo/middle/siunits#EMMO_99296e55_53f7_4333_9e06_760ad175a1b9"/>
-            <rdf:Description rdf:about="http://emmo.info/emmo/middle/siunits#EMMO_f96feb3f_4438_4e43_aa44_7458c4d87fc2"/>
-            <rdf:Description rdf:about="http://emmo.info/emmo/middle/siunits#EMMO_ffc7735f_c177_46a4_98e9_a54440d29209"/>
-        </owl:disjointUnionOf>
         <annotations:EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9>Physical constant that by definition (after the latest revision of the SI system that was enforsed May 2019) has a known exact numerical value when expressed in SI units.</annotations:EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9>
         <rdfs:label xml:lang="en">SIExactConstant</rdfs:label>
     </owl:Class>
@@ -1580,6 +1569,7 @@ Sievert is derived from absorbed dose, but takes into account the biological eff
 
     <owl:Class rdf:about="http://emmo.info/emmo/middle/siunits#EMMO_f96feb3f_4438_4e43_aa44_7458c4d87fc2">
         <rdfs:subClassOf rdf:resource="http://emmo.info/emmo/middle/isq#EMMO_852b4ab8_fc29_4749_a8c7_b92d4fca7d5a"/>
+        <rdfs:subClassOf rdf:resource="http://emmo.info/emmo/middle/siunits#EMMO_f2ca6dd0_0e5f_4392_a92d_cafdae6cfc95"/>
         <annotations:EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9>The frequency standard in the SI system in which the photon absorption by transitions between the two hyperfine ground states of caesium-133 atoms are used to control the output frequency.</annotations:EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9>
         <rdfs:label xml:lang="en">HyperfineTransitionFrequencyOfCs</rdfs:label>
     </owl:Class>
@@ -1630,6 +1620,7 @@ Sievert is derived from absorbed dose, but takes into account the biological eff
     <!-- http://emmo.info/emmo/middle/siunits#EMMO_ffc7735f_c177_46a4_98e9_a54440d29209 -->
 
     <owl:Class rdf:about="http://emmo.info/emmo/middle/siunits#EMMO_ffc7735f_c177_46a4_98e9_a54440d29209">
+        <rdfs:subClassOf rdf:resource="http://emmo.info/emmo/middle/siunits#EMMO_f2ca6dd0_0e5f_4392_a92d_cafdae6cfc95"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://emmo.info/emmo/middle/metrology#EMMO_67fc0a36_8dcb_4ffa_9a43_31074efa3296"/>
@@ -1648,9 +1639,12 @@ Sievert is derived from absorbed dose, but takes into account the biological eff
         <rdfs:comment>The DBpedia definition (http://dbpedia.org/page/Boltzmann_constant) is outdated as May 20, 2019. It is now an exact quantity.</rdfs:comment>
         <rdfs:label xml:lang="en">BoltzmannConstant</rdfs:label>
     </owl:Class>
+    <rdf:Description>
+        <owl:qualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</owl:qualifiedCardinality>
+    </rdf:Description>
 </rdf:RDF>
 
 
 
-<!-- Generated by the OWL API (version 4.2.8.20170104-2310) https://github.com/owlcs/owlapi -->
+<!-- Generated by the OWL API (version 4.5.9.2019-02-01T07:24:44Z) https://github.com/owlcs/owlapi -->
 

--- a/middle/units-extension.owl
+++ b/middle/units-extension.owl
@@ -111,7 +111,7 @@ Version 1.0.0-alpha2</owl:versionInfo>
                 <owl:allValuesFrom>
                     <owl:Restriction>
                         <owl:onProperty rdf:resource="http://emmo.info/emmo/middle/metrology#EMMO_bed1d005_b04e_4a90_94cf_02bc678a8569"/>
-                        <owl:allValuesFrom rdf:resource="http://emmo.info/emmo/middle/isq#EMMO_3227b821_26a5_4c7c_9c01_5c24483e0bd0"/>
+                        <owl:allValuesFrom rdf:resource="http://emmo.info/emmo/middle/metrology#EMMO_3227b821_26a5_4c7c_9c01_5c24483e0bd0"/>
                     </owl:Restriction>
                 </owl:allValuesFrom>
             </owl:Restriction>
@@ -409,7 +409,7 @@ Dispite of that, it is often used in the natural sciences and technology.</rdfs:
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://emmo.info/emmo/middle/metrology#EMMO_bed1d005_b04e_4a90_94cf_02bc678a8569"/>
-                <owl:allValuesFrom rdf:resource="http://emmo.info/emmo/middle/isq#EMMO_3227b821_26a5_4c7c_9c01_5c24483e0bd0"/>
+                <owl:allValuesFrom rdf:resource="http://emmo.info/emmo/middle/metrology#EMMO_3227b821_26a5_4c7c_9c01_5c24483e0bd0"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <rdfs:subClassOf>
@@ -550,7 +550,7 @@ Dispite of that, it is often used in the natural sciences and technology.</rdfs:
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://emmo.info/emmo/middle/metrology#EMMO_bed1d005_b04e_4a90_94cf_02bc678a8569"/>
-                <owl:allValuesFrom rdf:resource="http://emmo.info/emmo/middle/isq#EMMO_3227b821_26a5_4c7c_9c01_5c24483e0bd0"/>
+                <owl:allValuesFrom rdf:resource="http://emmo.info/emmo/middle/metrology#EMMO_3227b821_26a5_4c7c_9c01_5c24483e0bd0"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <rdfs:subClassOf>
@@ -739,7 +739,7 @@ Wikipedia</annotations:EMMO_70fe84ff_99b6_4206_a9fc_9a8931836d84>
                 <owl:allValuesFrom>
                     <owl:Restriction>
                         <owl:onProperty rdf:resource="http://emmo.info/emmo/middle/metrology#EMMO_bed1d005_b04e_4a90_94cf_02bc678a8569"/>
-                        <owl:allValuesFrom rdf:resource="http://emmo.info/emmo/middle/isq#EMMO_3227b821_26a5_4c7c_9c01_5c24483e0bd0"/>
+                        <owl:allValuesFrom rdf:resource="http://emmo.info/emmo/middle/metrology#EMMO_3227b821_26a5_4c7c_9c01_5c24483e0bd0"/>
                     </owl:Restriction>
                 </owl:allValuesFrom>
             </owl:Restriction>
@@ -1008,7 +1008,7 @@ Wikipedia</annotations:EMMO_70fe84ff_99b6_4206_a9fc_9a8931836d84>
                 <owl:allValuesFrom>
                     <owl:Restriction>
                         <owl:onProperty rdf:resource="http://emmo.info/emmo/middle/metrology#EMMO_bed1d005_b04e_4a90_94cf_02bc678a8569"/>
-                        <owl:allValuesFrom rdf:resource="http://emmo.info/emmo/middle/isq#EMMO_3227b821_26a5_4c7c_9c01_5c24483e0bd0"/>
+                        <owl:allValuesFrom rdf:resource="http://emmo.info/emmo/middle/metrology#EMMO_3227b821_26a5_4c7c_9c01_5c24483e0bd0"/>
                     </owl:Restriction>
                 </owl:allValuesFrom>
             </owl:Restriction>

--- a/middle/units-extension.owl
+++ b/middle/units-extension.owl
@@ -1,0 +1,686 @@
+<?xml version="1.0"?>
+<rdf:RDF xmlns="http://emmc.info/middle/units-extension#"
+     xml:base="http://emmc.info/middle/units-extension"
+     xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+     xmlns:owl="http://www.w3.org/2002/07/owl#"
+     xmlns:xml="http://www.w3.org/XML/1998/namespace"
+     xmlns:xsd="http://www.w3.org/2001/XMLSchema#"
+     xmlns:annotations="http://emmo.info/emmo/top/annotations#"
+     xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">
+    <owl:Ontology rdf:about="http://emmc.info/middle/units-extension">
+        <owl:versionIRI rdf:resource="http://emmc.info/middle/1.0.0-alpha2/units-extension"/>
+        <owl:imports rdf:resource="http://emmo.info/emmo/1.0.0-alpha2/middle/materials"/>
+        <owl:imports rdf:resource="http://emmo.info/emmo/1.0.0-alpha2/middle/siunits"/>
+        <annotations:EMMO_cd5fb112_7ee7_4120_a35d_3ca3e6c3f4ab>Emanuele Ghedini (University of Bologna, IT)
+Gerhard Goldbeck (GCL Ltd, UK)
+Adham Hashibon (Fraunhofer IWM, DE)
+Georg Schmitz (Access, DE)
+Jesper Friis (SINTEF, NO)</annotations:EMMO_cd5fb112_7ee7_4120_a35d_3ca3e6c3f4ab>
+        <annotations:EMMO_5525a055_dda5_4556_8b91_f0d22fa676cc>EMMO is released under a Creative Commons license Attribution 4.0 International (CC BY 4.0)
+
+https://creativecommons.org/licenses/by/4.0/legalcode</annotations:EMMO_5525a055_dda5_4556_8b91_f0d22fa676cc>
+        <owl:versionInfo>The European Materials Modelling Ontology
+
+Version 1.0.0-alpha2</owl:versionInfo>
+        <rdfs:comment>Contacts:
+Gerhard Goldbeck
+Goldbeck Consulting Ltd (UK)
+email: gerhard@goldbeck-consulting.com
+
+Emanuele Ghedini
+University of Bologna (IT)
+email: emanuele.ghedini@unibo.it</rdfs:comment>
+        <rdfs:comment>The EMMO requires FacT++ reasoner plugin in order to visualize all inferences and class hierarchy (ctrl+R hotkey in Protege).</rdfs:comment>
+        <rdfs:comment>European Materials and Modelling Ontology (EMMO)
+
+EMMO is a multidisciplinary effort to develop a standard representational framework (the ontology) based on current materials modelling knowledge, including physical sciences, analytical philosophy and information and communication technologies. 
+
+It provides the connection between the physical world, materials characterisation world and materials modelling world.</rdfs:comment>
+    </owl:Ontology>
+    
+
+
+    <!-- 
+    ///////////////////////////////////////////////////////////////////////////////////////
+    //
+    // Classes
+    //
+    ///////////////////////////////////////////////////////////////////////////////////////
+     -->
+
+    
+
+
+    <!-- http://emmc.info/middle/units-extension#EMMO_00dd79e0_31a6_427e_9b9c_90f3097e4a96 -->
+
+    <owl:Class rdf:about="http://emmc.info/middle/units-extension#EMMO_00dd79e0_31a6_427e_9b9c_90f3097e4a96">
+        <rdfs:subClassOf rdf:resource="http://emmo.info/emmo/middle/metrology#EMMO_591e02fd_8d37_45a6_9d11_bb21cef391a0"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://emmo.info/emmo/middle/metrology#EMMO_bed1d005_b04e_4a90_94cf_02bc678a8569"/>
+                <owl:allValuesFrom rdf:resource="http://emmo.info/emmo/middle/isq#EMMO_77e9dc31_5b19_463e_b000_44c6e79f98aa"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://emmo.info/emmo/middle/perceptual#EMMO_23b579e1_8088_45b5_9975_064014026c42"/>
+                <owl:hasValue>Da</owl:hasValue>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <annotations:EMMO_1f1b164d_ec6a_4faa_8d5e_88bda62316cc>http://qudt.org/vocab/unit/Dalton</annotations:EMMO_1f1b164d_ec6a_4faa_8d5e_88bda62316cc>
+        <annotations:EMMO_6dd685dd_1895_46e4_b227_be9f7d643c25>http://dbpedia.org/page/Unified_atomic_mass_unit</annotations:EMMO_6dd685dd_1895_46e4_b227_be9f7d643c25>
+        <annotations:EMMO_70fe84ff_99b6_4206_a9fc_9a8931836d84>One dalton is defined as one twelfth of the mass of an unbound neutral atom of carbon-12 in its nuclear and electronic ground state.</annotations:EMMO_70fe84ff_99b6_4206_a9fc_9a8931836d84>
+        <annotations:EMMO_fe015383_afb3_44a6_ae86_043628697aa2>https://doi.org/10.1351/goldbook.D01514</annotations:EMMO_fe015383_afb3_44a6_ae86_043628697aa2>
+        <rdfs:label xml:lang="en">Dalton</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://emmc.info/middle/units-extension#EMMO_053648ea_3c0a_468c_89cb_eb009239323a -->
+
+    <owl:Class rdf:about="http://emmc.info/middle/units-extension#EMMO_053648ea_3c0a_468c_89cb_eb009239323a">
+        <rdfs:subClassOf rdf:resource="http://emmo.info/emmo/middle/metrology#EMMO_591e02fd_8d37_45a6_9d11_bb21cef391a0"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://emmo.info/emmo/middle/metrology#EMMO_bed1d005_b04e_4a90_94cf_02bc678a8569"/>
+                <owl:allValuesFrom rdf:resource="http://emmo.info/emmo/middle/isq#EMMO_b3600e73_3e05_479d_9714_c041c3acf5cc"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://emmo.info/emmo/middle/perceptual#EMMO_23b579e1_8088_45b5_9975_064014026c42"/>
+                <owl:hasValue>au</owl:hasValue>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <annotations:EMMO_1f1b164d_ec6a_4faa_8d5e_88bda62316cc>http://qudt.org/vocab/unit/PARSEC</annotations:EMMO_1f1b164d_ec6a_4faa_8d5e_88bda62316cc>
+        <annotations:EMMO_6dd685dd_1895_46e4_b227_be9f7d643c25>http://dbpedia.org/page/Astronomical_unit</annotations:EMMO_6dd685dd_1895_46e4_b227_be9f7d643c25>
+        <annotations:EMMO_70fe84ff_99b6_4206_a9fc_9a8931836d84>One astronomical unit is defined as exactly 149597870700 m, which is roughly the distance from earth to sun.</annotations:EMMO_70fe84ff_99b6_4206_a9fc_9a8931836d84>
+        <annotations:EMMO_c84c6752_6d64_48cc_9500_e54a3c34898d>https://en.wikipedia.org/wiki/Astronomical_unit</annotations:EMMO_c84c6752_6d64_48cc_9500_e54a3c34898d>
+        <rdfs:label xml:lang="en">AstronomicalUnit</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://emmc.info/middle/units-extension#EMMO_07de47e0_6bb6_45b9_b55a_4f238efbb105 -->
+
+    <owl:Class rdf:about="http://emmc.info/middle/units-extension#EMMO_07de47e0_6bb6_45b9_b55a_4f238efbb105">
+        <rdfs:subClassOf rdf:resource="http://emmc.info/middle/units-extension#EMMO_46f30c91_bac0_42ff_8be9_950efe4ee7f1"/>
+        <annotations:EMMO_6dd685dd_1895_46e4_b227_be9f7d643c25>http://dbpedia.org/page/Atomic_number</annotations:EMMO_6dd685dd_1895_46e4_b227_be9f7d643c25>
+        <annotations:EMMO_70fe84ff_99b6_4206_a9fc_9a8931836d84>Number of protons in an atomic nucleus.</annotations:EMMO_70fe84ff_99b6_4206_a9fc_9a8931836d84>
+        <annotations:EMMO_fe015383_afb3_44a6_ae86_043628697aa2>https://doi.org/10.1351/goldbook.A00499</annotations:EMMO_fe015383_afb3_44a6_ae86_043628697aa2>
+        <rdfs:label xml:lang="en">AtomicNumber</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://emmc.info/middle/units-extension#EMMO_1e0b665d_db6c_4752_a6d4_262d3a8dbb46 -->
+
+    <owl:Class rdf:about="http://emmc.info/middle/units-extension#EMMO_1e0b665d_db6c_4752_a6d4_262d3a8dbb46">
+        <rdfs:subClassOf rdf:resource="http://emmo.info/emmo/middle/metrology#EMMO_591e02fd_8d37_45a6_9d11_bb21cef391a0"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://emmo.info/emmo/middle/metrology#EMMO_bed1d005_b04e_4a90_94cf_02bc678a8569"/>
+                <owl:allValuesFrom rdf:resource="http://emmc.info/middle/units-extension#EMMO_ed647204_fa50_4599_8f7e_4167cc4d2fb5"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://emmo.info/emmo/middle/perceptual#EMMO_23b579e1_8088_45b5_9975_064014026c42"/>
+                <owl:hasValue>′</owl:hasValue>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <annotations:EMMO_1f1b164d_ec6a_4faa_8d5e_88bda62316cc>http://qudt.org/vocab/unit/ARCMIN</annotations:EMMO_1f1b164d_ec6a_4faa_8d5e_88bda62316cc>
+        <annotations:EMMO_21ae69b4_235e_479d_8dd8_4f756f694c1b>MinuteOfArc</annotations:EMMO_21ae69b4_235e_479d_8dd8_4f756f694c1b>
+        <annotations:EMMO_70fe84ff_99b6_4206_a9fc_9a8931836d84>Measure of plane angle defined as 1/60 or a degree.</annotations:EMMO_70fe84ff_99b6_4206_a9fc_9a8931836d84>
+        <rdfs:label xml:lang="en">ArcMinute</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://emmc.info/middle/units-extension#EMMO_21ef2ed6_c086_4d24_8a75_980d2bcc9282 -->
+
+    <owl:Class rdf:about="http://emmc.info/middle/units-extension#EMMO_21ef2ed6_c086_4d24_8a75_980d2bcc9282">
+        <rdfs:subClassOf rdf:resource="http://emmo.info/emmo/middle/metrology#EMMO_591e02fd_8d37_45a6_9d11_bb21cef391a0"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://emmo.info/emmo/middle/metrology#EMMO_bed1d005_b04e_4a90_94cf_02bc678a8569"/>
+                <owl:allValuesFrom rdf:resource="http://emmo.info/emmo/middle/isq#EMMO_02e894c3_b793_4197_b120_3442e08f58d1"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://emmo.info/emmo/middle/perceptual#EMMO_23b579e1_8088_45b5_9975_064014026c42"/>
+                <owl:hasValue>h</owl:hasValue>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <annotations:EMMO_1f1b164d_ec6a_4faa_8d5e_88bda62316cc>http://qudt.org/vocab/unit/HR</annotations:EMMO_1f1b164d_ec6a_4faa_8d5e_88bda62316cc>
+        <annotations:EMMO_70fe84ff_99b6_4206_a9fc_9a8931836d84>Measure of time defined as 3600 seconds.</annotations:EMMO_70fe84ff_99b6_4206_a9fc_9a8931836d84>
+        <annotations:EMMO_fe015383_afb3_44a6_ae86_043628697aa2>https://doi.org/10.1351/goldbook.H02866</annotations:EMMO_fe015383_afb3_44a6_ae86_043628697aa2>
+        <rdfs:label xml:lang="en">Hour</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://emmc.info/middle/units-extension#EMMO_27367073_ed8a_481a_9b07_f836dfe31f7f -->
+
+    <owl:Class rdf:about="http://emmc.info/middle/units-extension#EMMO_27367073_ed8a_481a_9b07_f836dfe31f7f">
+        <rdfs:subClassOf rdf:resource="http://emmo.info/emmo/middle/isq#EMMO_ed4af7ae_63a2_497e_bb88_2309619ea405"/>
+        <annotations:EMMO_70fe84ff_99b6_4206_a9fc_9a8931836d84>The mass of an atom in the ground state.</annotations:EMMO_70fe84ff_99b6_4206_a9fc_9a8931836d84>
+        <annotations:EMMO_c84c6752_6d64_48cc_9500_e54a3c34898d>https://en.wikipedia.org/wiki/Atomic_mass</annotations:EMMO_c84c6752_6d64_48cc_9500_e54a3c34898d>
+        <annotations:EMMO_fe015383_afb3_44a6_ae86_043628697aa2>https://doi.org/10.1351/goldbook.A00496</annotations:EMMO_fe015383_afb3_44a6_ae86_043628697aa2>
+        <rdfs:comment>Since the nucleus account for nearly all of the total mass of atoms  (with the electrons and nuclear binding energy making minor contributions), the atomic mass measured in Da has nearly the same value as the mass number.</rdfs:comment>
+        <rdfs:comment>The atomic mass is often expressed as an average of the commonly found isotopes.</rdfs:comment>
+        <rdfs:label xml:lang="en">AtomicMass</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://emmc.info/middle/units-extension#EMMO_27c530c4_dfcd_486e_b324_54ad4448cd26 -->
+
+    <owl:Class rdf:about="http://emmc.info/middle/units-extension#EMMO_27c530c4_dfcd_486e_b324_54ad4448cd26">
+        <rdfs:subClassOf rdf:resource="http://emmo.info/emmo/middle/metrology#EMMO_591e02fd_8d37_45a6_9d11_bb21cef391a0"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://emmo.info/emmo/middle/metrology#EMMO_bed1d005_b04e_4a90_94cf_02bc678a8569"/>
+                <owl:allValuesFrom rdf:resource="http://emmo.info/emmo/middle/isq#EMMO_b3600e73_3e05_479d_9714_c041c3acf5cc"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://emmo.info/emmo/middle/perceptual#EMMO_23b579e1_8088_45b5_9975_064014026c42"/>
+                <owl:hasValue>Å</owl:hasValue>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <annotations:EMMO_1f1b164d_ec6a_4faa_8d5e_88bda62316cc>http://qudt.org/vocab/unit/ANGSTROM</annotations:EMMO_1f1b164d_ec6a_4faa_8d5e_88bda62316cc>
+        <annotations:EMMO_21ae69b4_235e_479d_8dd8_4f756f694c1b>Angstrom</annotations:EMMO_21ae69b4_235e_479d_8dd8_4f756f694c1b>
+        <annotations:EMMO_6dd685dd_1895_46e4_b227_be9f7d643c25>http://dbpedia.org/page/%C3%85ngstr%C3%B6m</annotations:EMMO_6dd685dd_1895_46e4_b227_be9f7d643c25>
+        <annotations:EMMO_70fe84ff_99b6_4206_a9fc_9a8931836d84>Measure of length defined as 1e-10 metres.</annotations:EMMO_70fe84ff_99b6_4206_a9fc_9a8931836d84>
+        <annotations:EMMO_c84c6752_6d64_48cc_9500_e54a3c34898d>https://en.wikipedia.org/wiki/Angstrom</annotations:EMMO_c84c6752_6d64_48cc_9500_e54a3c34898d>
+        <annotations:EMMO_fe015383_afb3_44a6_ae86_043628697aa2>https://doi.org/10.1351/goldbook.N00350</annotations:EMMO_fe015383_afb3_44a6_ae86_043628697aa2>
+        <rdfs:comment>Ångström is not mentioned in the SI system and deprecated by the International Bureau of Weights and Measures (BIPM).
+
+Dispite of that, it is often used in the natural sciences and technology.</rdfs:comment>
+        <rdfs:label xml:lang="en">Ångström</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://emmc.info/middle/units-extension#EMMO_28ef05a7_ecc1_4df6_8116_c53251fbd4a8 -->
+
+    <owl:Class rdf:about="http://emmc.info/middle/units-extension#EMMO_28ef05a7_ecc1_4df6_8116_c53251fbd4a8">
+        <rdfs:subClassOf rdf:resource="http://emmo.info/emmo/middle/metrology#EMMO_591e02fd_8d37_45a6_9d11_bb21cef391a0"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://emmo.info/emmo/middle/metrology#EMMO_bed1d005_b04e_4a90_94cf_02bc678a8569"/>
+                <owl:allValuesFrom rdf:resource="http://emmo.info/emmo/middle/isq#EMMO_02e894c3_b793_4197_b120_3442e08f58d1"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://emmo.info/emmo/middle/perceptual#EMMO_23b579e1_8088_45b5_9975_064014026c42"/>
+                <owl:hasValue>d</owl:hasValue>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <annotations:EMMO_1f1b164d_ec6a_4faa_8d5e_88bda62316cc>http://qudt.org/vocab/unit/DAY</annotations:EMMO_1f1b164d_ec6a_4faa_8d5e_88bda62316cc>
+        <annotations:EMMO_6dd685dd_1895_46e4_b227_be9f7d643c25>http://dbpedia.org/page/Day</annotations:EMMO_6dd685dd_1895_46e4_b227_be9f7d643c25>
+        <annotations:EMMO_70fe84ff_99b6_4206_a9fc_9a8931836d84>A measure of time defined as 86 400 seconds.</annotations:EMMO_70fe84ff_99b6_4206_a9fc_9a8931836d84>
+        <annotations:EMMO_fe015383_afb3_44a6_ae86_043628697aa2>https://doi.org/10.1351/goldbook.D01527</annotations:EMMO_fe015383_afb3_44a6_ae86_043628697aa2>
+        <rdfs:label xml:lang="en">Day</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://emmc.info/middle/units-extension#EMMO_33433bb1_c68f_45ee_a466_f01e2c57b214 -->
+
+    <owl:Class rdf:about="http://emmc.info/middle/units-extension#EMMO_33433bb1_c68f_45ee_a466_f01e2c57b214">
+        <rdfs:subClassOf rdf:resource="http://emmo.info/emmo/middle/metrology#EMMO_9895a1b4_f0a5_4167_ac5e_97db40b8bfcc"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://emmo.info/emmo/middle/perceptual#EMMO_23b579e1_8088_45b5_9975_064014026c42"/>
+                <owl:hasValue>T0 L2 M0 I0 Θ0 N0 J0</owl:hasValue>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:label xml:lang="en">SquareLengthDimension</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://emmc.info/middle/units-extension#EMMO_42638511_1ba4_4487_b031_2a4030390c29 -->
+
+    <owl:Class rdf:about="http://emmc.info/middle/units-extension#EMMO_42638511_1ba4_4487_b031_2a4030390c29">
+        <rdfs:subClassOf rdf:resource="http://emmo.info/emmo/middle/metrology#EMMO_5ebd5e01_0ed3_49a2_a30d_cd05cbe72978"/>
+        <annotations:EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9>Dimensionless unit for the fraction of two volumes.</annotations:EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9>
+        <rdfs:label xml:lang="en">VolumePerVolumeUnit</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://emmc.info/middle/units-extension#EMMO_46f30c91_bac0_42ff_8be9_950efe4ee7f1 -->
+
+    <owl:Class rdf:about="http://emmc.info/middle/units-extension#EMMO_46f30c91_bac0_42ff_8be9_950efe4ee7f1">
+        <rdfs:subClassOf rdf:resource="http://emmo.info/emmo/middle/metrology#EMMO_71f6ab56_342c_484b_bbe0_de86b7367cb3"/>
+        <annotations:EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9>Derived quantities defined in ISO 80000-10:2019 Quantities and units — Part 10: Atomic and nuclear physics.</annotations:EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9>
+        <rdfs:label xml:lang="en">AtomAndNuclearPhysicsDerivedQuantity</rdfs:label>
+        <rdfs:seeAlso>https://www.iso.org/obp/ui/#iso:std:iso:80000:-10:ed-2:v1:en</rdfs:seeAlso>
+    </owl:Class>
+    
+
+
+    <!-- http://emmc.info/middle/units-extension#EMMO_470b044a_3df0_4f58_aa1a_2d6e27a8c928 -->
+
+    <owl:Class rdf:about="http://emmc.info/middle/units-extension#EMMO_470b044a_3df0_4f58_aa1a_2d6e27a8c928">
+        <rdfs:subClassOf rdf:resource="http://emmo.info/emmo/middle/metrology#EMMO_5ebd5e01_0ed3_49a2_a30d_cd05cbe72978"/>
+        <annotations:EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9>Dimensionless unit for the fraction of two amount of substances.</annotations:EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9>
+        <rdfs:label xml:lang="en">AmountPerAmountUnit</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://emmc.info/middle/units-extension#EMMO_52e4cb25_da39_45e2_a6db_063ec5730499 -->
+
+    <owl:Class rdf:about="http://emmc.info/middle/units-extension#EMMO_52e4cb25_da39_45e2_a6db_063ec5730499">
+        <rdfs:subClassOf rdf:resource="http://emmo.info/emmo/middle/metrology#EMMO_b081b346_7279_46ef_9a3d_2c088fcd79f4"/>
+        <annotations:EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9>The centimetre–gram–second (CGS) system of units.</annotations:EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9>
+        <annotations:EMMO_c84c6752_6d64_48cc_9500_e54a3c34898d>https://en.wikipedia.org/wiki/Centimetre%E2%80%93gram%E2%80%93second_system_of_units</annotations:EMMO_c84c6752_6d64_48cc_9500_e54a3c34898d>
+        <rdfs:comment>CGS is a variant of the metric system.</rdfs:comment>
+        <rdfs:label xml:lang="en">CGSUnit</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://emmc.info/middle/units-extension#EMMO_6795a4b8_ffd0_4588_a581_a9413fe49cac -->
+
+    <owl:Class rdf:about="http://emmc.info/middle/units-extension#EMMO_6795a4b8_ffd0_4588_a581_a9413fe49cac">
+        <rdfs:subClassOf rdf:resource="http://emmo.info/emmo/middle/metrology#EMMO_3ee80521_3c23_4dd1_935d_9d522614a3e2"/>
+        <owl:disjointUnionOf rdf:parseType="Collection">
+            <rdf:Description rdf:about="http://emmc.info/middle/units-extension#EMMO_00dd79e0_31a6_427e_9b9c_90f3097e4a96"/>
+            <rdf:Description rdf:about="http://emmc.info/middle/units-extension#EMMO_053648ea_3c0a_468c_89cb_eb009239323a"/>
+            <rdf:Description rdf:about="http://emmc.info/middle/units-extension#EMMO_1e0b665d_db6c_4752_a6d4_262d3a8dbb46"/>
+            <rdf:Description rdf:about="http://emmc.info/middle/units-extension#EMMO_21ef2ed6_c086_4d24_8a75_980d2bcc9282"/>
+            <rdf:Description rdf:about="http://emmc.info/middle/units-extension#EMMO_28ef05a7_ecc1_4df6_8116_c53251fbd4a8"/>
+            <rdf:Description rdf:about="http://emmc.info/middle/units-extension#EMMO_6a4547ab_3abb_430d_b81b_ce32d47729f5"/>
+            <rdf:Description rdf:about="http://emmc.info/middle/units-extension#EMMO_6c7160fc_cc64_46f0_b43b_aba65e9952e3"/>
+            <rdf:Description rdf:about="http://emmc.info/middle/units-extension#EMMO_a155dc93_d266_487e_b5e7_2a2c72d5ebf9"/>
+            <rdf:Description rdf:about="http://emmc.info/middle/units-extension#EMMO_b41515a9_28d8_4d78_8165_74b2fc72f89e"/>
+            <rdf:Description rdf:about="http://emmc.info/middle/units-extension#EMMO_b8830065_3809_41b7_be3c_e33795567fd9"/>
+            <rdf:Description rdf:about="http://emmc.info/middle/units-extension#EMMO_cabb20f0_05c7_448f_9485_e129725f15a4"/>
+            <rdf:Description rdf:about="http://emmc.info/middle/units-extension#EMMO_d6eb0176_a0d7_4b4e_8df0_50e912be2342"/>
+            <rdf:Description rdf:about="http://emmc.info/middle/units-extension#EMMO_e29f84db_4c1c_46ae_aa38_c4d47536b972"/>
+            <rdf:Description rdf:about="http://emmc.info/middle/units-extension#EMMO_f8b92999_3cde_46e3_99d5_664da3090a02"/>
+        </owl:disjointUnionOf>
+        <annotations:EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9>Non-SI units mentioned in the SI.</annotations:EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9>
+        <annotations:EMMO_c84c6752_6d64_48cc_9500_e54a3c34898d>https://en.wikipedia.org/wiki/Non-SI_units_mentioned_in_the_SI</annotations:EMMO_c84c6752_6d64_48cc_9500_e54a3c34898d>
+        <rdfs:comment>This is a list of units that are not defined as part of the International System of Units (SI), but are otherwise mentioned in the SI brouchure, because either the General Conference on Weights and Measures (CGPM) accepts their use as being multiples or submultiples of SI-units, they have important contemporary application worldwide, or are otherwise commonly encountered worldwide.</rdfs:comment>
+        <rdfs:label xml:lang="en">SIAcceptedSpecialUnit</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://emmc.info/middle/units-extension#EMMO_6a4547ab_3abb_430d_b81b_ce32d47729f5 -->
+
+    <owl:Class rdf:about="http://emmc.info/middle/units-extension#EMMO_6a4547ab_3abb_430d_b81b_ce32d47729f5">
+        <rdfs:subClassOf rdf:resource="http://emmo.info/emmo/middle/metrology#EMMO_591e02fd_8d37_45a6_9d11_bb21cef391a0"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://emmo.info/emmo/middle/metrology#EMMO_bed1d005_b04e_4a90_94cf_02bc678a8569"/>
+                <owl:allValuesFrom rdf:resource="http://emmc.info/middle/units-extension#EMMO_ed647204_fa50_4599_8f7e_4167cc4d2fb5"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://emmo.info/emmo/middle/perceptual#EMMO_23b579e1_8088_45b5_9975_064014026c42"/>
+                <owl:hasValue>″</owl:hasValue>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <annotations:EMMO_1f1b164d_ec6a_4faa_8d5e_88bda62316cc>http://qudt.org/vocab/unit/ARCSEC</annotations:EMMO_1f1b164d_ec6a_4faa_8d5e_88bda62316cc>
+        <annotations:EMMO_21ae69b4_235e_479d_8dd8_4f756f694c1b>SecondOfArc</annotations:EMMO_21ae69b4_235e_479d_8dd8_4f756f694c1b>
+        <annotations:EMMO_70fe84ff_99b6_4206_a9fc_9a8931836d84>Measure of plane angle defined as 1/3600 or a degree.</annotations:EMMO_70fe84ff_99b6_4206_a9fc_9a8931836d84>
+        <rdfs:label xml:lang="en">ArcSecond</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://emmc.info/middle/units-extension#EMMO_6c7160fc_cc64_46f0_b43b_aba65e9952e3 -->
+
+    <owl:Class rdf:about="http://emmc.info/middle/units-extension#EMMO_6c7160fc_cc64_46f0_b43b_aba65e9952e3">
+        <rdfs:subClassOf rdf:resource="http://emmo.info/emmo/middle/metrology#EMMO_591e02fd_8d37_45a6_9d11_bb21cef391a0"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://emmo.info/emmo/middle/metrology#EMMO_bed1d005_b04e_4a90_94cf_02bc678a8569"/>
+                <owl:allValuesFrom rdf:resource="http://emmo.info/emmo/middle/isq#EMMO_3227b821_26a5_4c7c_9c01_5c24483e0bd0"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://emmo.info/emmo/middle/perceptual#EMMO_23b579e1_8088_45b5_9975_064014026c42"/>
+                <owl:hasValue>B</owl:hasValue>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <annotations:EMMO_1f1b164d_ec6a_4faa_8d5e_88bda62316cc>http://qudt.org/vocab/unit/B</annotations:EMMO_1f1b164d_ec6a_4faa_8d5e_88bda62316cc>
+        <annotations:EMMO_70fe84ff_99b6_4206_a9fc_9a8931836d84>One bel is defined as `1⁄2 ln(10) neper`.</annotations:EMMO_70fe84ff_99b6_4206_a9fc_9a8931836d84>
+        <annotations:EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9>Unit of measurement for quantities of type level or level difference.</annotations:EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9>
+        <annotations:EMMO_c84c6752_6d64_48cc_9500_e54a3c34898d>https://en.wikipedia.org/wiki/Decibel</annotations:EMMO_c84c6752_6d64_48cc_9500_e54a3c34898d>
+        <rdfs:comment>Today decibel (one tenth of a bel) is commonly used instead of bel.</rdfs:comment>
+        <rdfs:comment>bel is used to express the ratio of one value of a power or field quantity to another, on a logarithmic scale, the logarithmic quantity being called the power level or field level, respectively.</rdfs:comment>
+        <rdfs:label xml:lang="en">Bel</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://emmc.info/middle/units-extension#EMMO_9141801c_c539_4c72_b423_8c74ff6b8f05 -->
+
+    <owl:Class rdf:about="http://emmc.info/middle/units-extension#EMMO_9141801c_c539_4c72_b423_8c74ff6b8f05">
+        <owl:equivalentClass>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://emmo.info/emmo/middle/perceptual#EMMO_23b579e1_8088_45b5_9975_064014026c42"/>
+                <owl:hasValue>T0 L+3 M0 I0 Θ0 N0 J0</owl:hasValue>
+            </owl:Restriction>
+        </owl:equivalentClass>
+        <rdfs:subClassOf rdf:resource="http://emmo.info/emmo/middle/metrology#EMMO_9895a1b4_f0a5_4167_ac5e_97db40b8bfcc"/>
+        <rdfs:label xml:lang="en">CubicLengthDimension</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://emmc.info/middle/units-extension#EMMO_a155dc93_d266_487e_b5e7_2a2c72d5ebf9 -->
+
+    <owl:Class rdf:about="http://emmc.info/middle/units-extension#EMMO_a155dc93_d266_487e_b5e7_2a2c72d5ebf9">
+        <rdfs:subClassOf rdf:resource="http://emmo.info/emmo/middle/metrology#EMMO_591e02fd_8d37_45a6_9d11_bb21cef391a0"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://emmo.info/emmo/middle/metrology#EMMO_bed1d005_b04e_4a90_94cf_02bc678a8569"/>
+                <owl:allValuesFrom rdf:resource="http://emmc.info/middle/units-extension#EMMO_9141801c_c539_4c72_b423_8c74ff6b8f05"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://emmo.info/emmo/middle/perceptual#EMMO_23b579e1_8088_45b5_9975_064014026c42"/>
+                <owl:hasValue>l</owl:hasValue>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <annotations:EMMO_1f1b164d_ec6a_4faa_8d5e_88bda62316cc>http://qudt.org/vocab/unit/L</annotations:EMMO_1f1b164d_ec6a_4faa_8d5e_88bda62316cc>
+        <annotations:EMMO_70fe84ff_99b6_4206_a9fc_9a8931836d84>A non-SI unit of volume defined as 1 cubic decimetre (dm3),</annotations:EMMO_70fe84ff_99b6_4206_a9fc_9a8931836d84>
+        <annotations:EMMO_fe015383_afb3_44a6_ae86_043628697aa2>https://doi.org/10.1351/goldbook.L03594</annotations:EMMO_fe015383_afb3_44a6_ae86_043628697aa2>
+        <rdfs:label xml:lang="en">Litre</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://emmc.info/middle/units-extension#EMMO_b41515a9_28d8_4d78_8165_74b2fc72f89e -->
+
+    <owl:Class rdf:about="http://emmc.info/middle/units-extension#EMMO_b41515a9_28d8_4d78_8165_74b2fc72f89e">
+        <rdfs:subClassOf rdf:resource="http://emmo.info/emmo/middle/metrology#EMMO_591e02fd_8d37_45a6_9d11_bb21cef391a0"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://emmo.info/emmo/middle/metrology#EMMO_bed1d005_b04e_4a90_94cf_02bc678a8569"/>
+                <owl:allValuesFrom rdf:resource="http://emmo.info/emmo/middle/isq#EMMO_3227b821_26a5_4c7c_9c01_5c24483e0bd0"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://emmo.info/emmo/middle/perceptual#EMMO_23b579e1_8088_45b5_9975_064014026c42"/>
+                <owl:hasValue>Np</owl:hasValue>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <annotations:EMMO_1f1b164d_ec6a_4faa_8d5e_88bda62316cc>http://qudt.org/vocab/unit/NP</annotations:EMMO_1f1b164d_ec6a_4faa_8d5e_88bda62316cc>
+        <annotations:EMMO_6dd685dd_1895_46e4_b227_be9f7d643c25>http://dbpedia.org/page/Neper</annotations:EMMO_6dd685dd_1895_46e4_b227_be9f7d643c25>
+        <annotations:EMMO_70fe84ff_99b6_4206_a9fc_9a8931836d84>Unit of measurement for quantities of type level or level difference, which are defined as the natural logarithm of the ratio of power- or field-type quantities.
+
+The value of a ratio in nepers is given by `ln(x1/x2)` where `x1` and `x2` are the values of interest (amplitudes), and ln is the natural logarithm. When the values are quadratic in the amplitude (e.g. power), they are first linearised by taking the square root before the logarithm is taken, or equivalently the result is halved.
+
+Wikipedia</annotations:EMMO_70fe84ff_99b6_4206_a9fc_9a8931836d84>
+        <annotations:EMMO_c84c6752_6d64_48cc_9500_e54a3c34898d>https://en.wikipedia.org/wiki/Neper</annotations:EMMO_c84c6752_6d64_48cc_9500_e54a3c34898d>
+        <annotations:EMMO_fe015383_afb3_44a6_ae86_043628697aa2>https://doi.org/10.1351/goldbook.N04106</annotations:EMMO_fe015383_afb3_44a6_ae86_043628697aa2>
+        <rdfs:label xml:lang="en">Neper</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://emmc.info/middle/units-extension#EMMO_b8830065_3809_41b7_be3c_e33795567fd9 -->
+
+    <owl:Class rdf:about="http://emmc.info/middle/units-extension#EMMO_b8830065_3809_41b7_be3c_e33795567fd9">
+        <rdfs:subClassOf rdf:resource="http://emmo.info/emmo/middle/metrology#EMMO_591e02fd_8d37_45a6_9d11_bb21cef391a0"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://emmo.info/emmo/middle/metrology#EMMO_bed1d005_b04e_4a90_94cf_02bc678a8569"/>
+                <owl:allValuesFrom rdf:resource="http://emmc.info/middle/units-extension#EMMO_ed647204_fa50_4599_8f7e_4167cc4d2fb5"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://emmo.info/emmo/middle/perceptual#EMMO_23b579e1_8088_45b5_9975_064014026c42"/>
+                <owl:hasValue>°</owl:hasValue>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <annotations:EMMO_1f1b164d_ec6a_4faa_8d5e_88bda62316cc>http://qudt.org/vocab/unit/DEG</annotations:EMMO_1f1b164d_ec6a_4faa_8d5e_88bda62316cc>
+        <annotations:EMMO_6dd685dd_1895_46e4_b227_be9f7d643c25>http://dbpedia.org/page/Degree_(angle)</annotations:EMMO_6dd685dd_1895_46e4_b227_be9f7d643c25>
+        <annotations:EMMO_70fe84ff_99b6_4206_a9fc_9a8931836d84>Degree is a measurement of plane angle, defined by representing a full rotation as 360 degrees.</annotations:EMMO_70fe84ff_99b6_4206_a9fc_9a8931836d84>
+        <annotations:EMMO_fe015383_afb3_44a6_ae86_043628697aa2>https://doi.org/10.1351/goldbook.D01560</annotations:EMMO_fe015383_afb3_44a6_ae86_043628697aa2>
+        <rdfs:label xml:lang="en">Degree</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://emmc.info/middle/units-extension#EMMO_bb39e45f_aeac_4585_8f97_f86213f3f401 -->
+
+    <owl:Class rdf:about="http://emmc.info/middle/units-extension#EMMO_bb39e45f_aeac_4585_8f97_f86213f3f401">
+        <rdfs:subClassOf rdf:resource="http://emmo.info/emmo/middle/metrology#EMMO_5ebd5e01_0ed3_49a2_a30d_cd05cbe72978"/>
+        <annotations:EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9>Dimensionless unit for the fraction of two masses.</annotations:EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9>
+        <rdfs:label xml:lang="en">MassPerMassUnit</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://emmc.info/middle/units-extension#EMMO_cabb20f0_05c7_448f_9485_e129725f15a4 -->
+
+    <owl:Class rdf:about="http://emmc.info/middle/units-extension#EMMO_cabb20f0_05c7_448f_9485_e129725f15a4">
+        <rdfs:subClassOf rdf:resource="http://emmo.info/emmo/middle/metrology#EMMO_591e02fd_8d37_45a6_9d11_bb21cef391a0"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://emmo.info/emmo/middle/metrology#EMMO_bed1d005_b04e_4a90_94cf_02bc678a8569"/>
+                <owl:allValuesFrom rdf:resource="http://emmo.info/emmo/middle/isq#EMMO_02e894c3_b793_4197_b120_3442e08f58d1"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://emmo.info/emmo/middle/perceptual#EMMO_23b579e1_8088_45b5_9975_064014026c42"/>
+                <owl:hasValue>min</owl:hasValue>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <annotations:EMMO_1f1b164d_ec6a_4faa_8d5e_88bda62316cc>http://qudt.org/vocab/unit/MIN</annotations:EMMO_1f1b164d_ec6a_4faa_8d5e_88bda62316cc>
+        <annotations:EMMO_6dd685dd_1895_46e4_b227_be9f7d643c25>http://dbpedia.org/page/Minute</annotations:EMMO_6dd685dd_1895_46e4_b227_be9f7d643c25>
+        <annotations:EMMO_70fe84ff_99b6_4206_a9fc_9a8931836d84>Non-SI time unit defined as 60 seconds.</annotations:EMMO_70fe84ff_99b6_4206_a9fc_9a8931836d84>
+        <rdfs:label xml:lang="en">Minute</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://emmc.info/middle/units-extension#EMMO_cce78743_ea7c_48f9_9154_5372a60219dc -->
+
+    <owl:Class rdf:about="http://emmc.info/middle/units-extension#EMMO_cce78743_ea7c_48f9_9154_5372a60219dc">
+        <rdfs:subClassOf rdf:resource="http://emmo.info/emmo/middle/metrology#EMMO_5ebd5e01_0ed3_49a2_a30d_cd05cbe72978"/>
+        <annotations:EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9>Dimensionless unit for the fraction of two velocities.</annotations:EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9>
+        <rdfs:label xml:lang="en">VelocityPerVelociryUnit</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://emmc.info/middle/units-extension#EMMO_d6eb0176_a0d7_4b4e_8df0_50e912be2342 -->
+
+    <owl:Class rdf:about="http://emmc.info/middle/units-extension#EMMO_d6eb0176_a0d7_4b4e_8df0_50e912be2342">
+        <rdfs:subClassOf rdf:resource="http://emmo.info/emmo/middle/metrology#EMMO_591e02fd_8d37_45a6_9d11_bb21cef391a0"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://emmo.info/emmo/middle/metrology#EMMO_bed1d005_b04e_4a90_94cf_02bc678a8569"/>
+                <owl:allValuesFrom rdf:resource="http://emmc.info/middle/units-extension#EMMO_33433bb1_c68f_45ee_a466_f01e2c57b214"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://emmo.info/emmo/middle/perceptual#EMMO_23b579e1_8088_45b5_9975_064014026c42"/>
+                <owl:hasValue>ha</owl:hasValue>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <annotations:EMMO_1f1b164d_ec6a_4faa_8d5e_88bda62316cc>http://qudt.org/vocab/unit/HA</annotations:EMMO_1f1b164d_ec6a_4faa_8d5e_88bda62316cc>
+        <annotations:EMMO_6dd685dd_1895_46e4_b227_be9f7d643c25>http://dbpedia.org/page/Hectare</annotations:EMMO_6dd685dd_1895_46e4_b227_be9f7d643c25>
+        <annotations:EMMO_70fe84ff_99b6_4206_a9fc_9a8931836d84>A non-SI metric unit of area defined as the square with 100-metre sides.</annotations:EMMO_70fe84ff_99b6_4206_a9fc_9a8931836d84>
+        <annotations:EMMO_c84c6752_6d64_48cc_9500_e54a3c34898d>https://en.wikipedia.org/wiki/Hectare</annotations:EMMO_c84c6752_6d64_48cc_9500_e54a3c34898d>
+        <rdfs:label xml:lang="en">Hectare</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://emmc.info/middle/units-extension#EMMO_dc6c8de0_cfc4_4c66_a7dc_8f720e732d54 -->
+
+    <owl:Class rdf:about="http://emmc.info/middle/units-extension#EMMO_dc6c8de0_cfc4_4c66_a7dc_8f720e732d54">
+        <rdfs:subClassOf rdf:resource="http://emmc.info/middle/units-extension#EMMO_46f30c91_bac0_42ff_8be9_950efe4ee7f1"/>
+        <annotations:EMMO_70fe84ff_99b6_4206_a9fc_9a8931836d84>Number of nucleons in an atomic nucleus.</annotations:EMMO_70fe84ff_99b6_4206_a9fc_9a8931836d84>
+        <rdfs:label xml:lang="en">MassNumber</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://emmc.info/middle/units-extension#EMMO_e29f84db_4c1c_46ae_aa38_c4d47536b972 -->
+
+    <owl:Class rdf:about="http://emmc.info/middle/units-extension#EMMO_e29f84db_4c1c_46ae_aa38_c4d47536b972">
+        <rdfs:subClassOf rdf:resource="http://emmo.info/emmo/middle/metrology#EMMO_591e02fd_8d37_45a6_9d11_bb21cef391a0"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://emmo.info/emmo/middle/metrology#EMMO_bed1d005_b04e_4a90_94cf_02bc678a8569"/>
+                <owl:allValuesFrom rdf:resource="http://emmo.info/emmo/middle/isq#EMMO_f6070071_d054_4b17_9d2d_f446f7147d0f"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://emmo.info/emmo/middle/perceptual#EMMO_23b579e1_8088_45b5_9975_064014026c42"/>
+                <owl:hasValue>eV</owl:hasValue>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <annotations:EMMO_1f1b164d_ec6a_4faa_8d5e_88bda62316cc>http://qudt.org/vocab/unit/EV</annotations:EMMO_1f1b164d_ec6a_4faa_8d5e_88bda62316cc>
+        <annotations:EMMO_6dd685dd_1895_46e4_b227_be9f7d643c25>http://dbpedia.org/page/Electronvolt</annotations:EMMO_6dd685dd_1895_46e4_b227_be9f7d643c25>
+        <annotations:EMMO_70fe84ff_99b6_4206_a9fc_9a8931836d84>The amount of energy gained (or lost) by the charge of a single electron moving across an electric potential difference of one volt.</annotations:EMMO_70fe84ff_99b6_4206_a9fc_9a8931836d84>
+        <annotations:EMMO_fe015383_afb3_44a6_ae86_043628697aa2>https://doi.org/10.1351/goldbook.E02014</annotations:EMMO_fe015383_afb3_44a6_ae86_043628697aa2>
+        <rdfs:label xml:lang="en">ElectronVolt</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://emmc.info/middle/units-extension#EMMO_ed647204_fa50_4599_8f7e_4167cc4d2fb5 -->
+
+    <owl:Class rdf:about="http://emmc.info/middle/units-extension#EMMO_ed647204_fa50_4599_8f7e_4167cc4d2fb5">
+        <rdfs:subClassOf rdf:resource="http://emmo.info/emmo/middle/metrology#EMMO_5ebd5e01_0ed3_49a2_a30d_cd05cbe72978"/>
+        <annotations:EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9>Dimensionless unit for the fraction of two lengths.</annotations:EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9>
+        <rdfs:label xml:lang="en">LengthPerLengthUnit</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://emmc.info/middle/units-extension#EMMO_f8b92999_3cde_46e3_99d5_664da3090a02 -->
+
+    <owl:Class rdf:about="http://emmc.info/middle/units-extension#EMMO_f8b92999_3cde_46e3_99d5_664da3090a02">
+        <rdfs:subClassOf rdf:resource="http://emmo.info/emmo/middle/metrology#EMMO_591e02fd_8d37_45a6_9d11_bb21cef391a0"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://emmo.info/emmo/middle/metrology#EMMO_bed1d005_b04e_4a90_94cf_02bc678a8569"/>
+                <owl:allValuesFrom rdf:resource="http://emmo.info/emmo/middle/isq#EMMO_77e9dc31_5b19_463e_b000_44c6e79f98aa"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://emmo.info/emmo/middle/perceptual#EMMO_23b579e1_8088_45b5_9975_064014026c42"/>
+                <owl:hasValue>t</owl:hasValue>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <annotations:EMMO_1f1b164d_ec6a_4faa_8d5e_88bda62316cc>http://qudt.org/vocab/unit/TON_M</annotations:EMMO_1f1b164d_ec6a_4faa_8d5e_88bda62316cc>
+        <annotations:EMMO_70fe84ff_99b6_4206_a9fc_9a8931836d84>A non-SI unit defined as 1000 kg.</annotations:EMMO_70fe84ff_99b6_4206_a9fc_9a8931836d84>
+        <annotations:EMMO_c84c6752_6d64_48cc_9500_e54a3c34898d>https://en.wikipedia.org/wiki/Tonne</annotations:EMMO_c84c6752_6d64_48cc_9500_e54a3c34898d>
+        <annotations:EMMO_fe015383_afb3_44a6_ae86_043628697aa2>https://doi.org/10.1351/goldbook.T06394</annotations:EMMO_fe015383_afb3_44a6_ae86_043628697aa2>
+        <rdfs:label xml:lang="en">Tonne</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://emmc.info/middle/units-extension#EMMO_f992dc76_f9a6_45f6_8873_c8e20d16fbbe -->
+
+    <owl:Class rdf:about="http://emmc.info/middle/units-extension#EMMO_f992dc76_f9a6_45f6_8873_c8e20d16fbbe">
+        <rdfs:subClassOf rdf:resource="http://emmc.info/middle/units-extension#EMMO_52e4cb25_da39_45e2_a6db_063ec5730499"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://emmo.info/emmo/middle/metrology#EMMO_bed1d005_b04e_4a90_94cf_02bc678a8569"/>
+                <owl:allValuesFrom rdf:resource="http://emmo.info/emmo/middle/isq#EMMO_77e9dc31_5b19_463e_b000_44c6e79f98aa"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://emmo.info/emmo/middle/perceptual#EMMO_23b579e1_8088_45b5_9975_064014026c42"/>
+                <owl:hasValue>g</owl:hasValue>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <annotations:EMMO_70fe84ff_99b6_4206_a9fc_9a8931836d84>Gram is defined as one thousandth of the SI unit kilogram.</annotations:EMMO_70fe84ff_99b6_4206_a9fc_9a8931836d84>
+        <annotations:EMMO_c84c6752_6d64_48cc_9500_e54a3c34898d>https://en.wikipedia.org/wiki/Gram</annotations:EMMO_c84c6752_6d64_48cc_9500_e54a3c34898d>
+        <annotations:EMMO_fe015383_afb3_44a6_ae86_043628697aa2>https://doi.org/10.1351/goldbook.G02680</annotations:EMMO_fe015383_afb3_44a6_ae86_043628697aa2>
+        <rdfs:label xml:lang="en">Gram</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://emmc.info/middle/units-extension#EMMO_f9b13cf7_b8c5_4222_aa89_f9ccfa8c7c7c -->
+
+    <owl:Class rdf:about="http://emmc.info/middle/units-extension#EMMO_f9b13cf7_b8c5_4222_aa89_f9ccfa8c7c7c">
+        <rdfs:subClassOf rdf:resource="http://emmo.info/emmo/middle/metrology#EMMO_5ebd5e01_0ed3_49a2_a30d_cd05cbe72978"/>
+        <annotations:EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9>Dimensionless unit for the fraction of two areas.</annotations:EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9>
+        <rdfs:label xml:lang="en">AreaPerAreaUnit</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://emmo.info/emmo/middle/materials#EMMO_eb77076b_a104_42ac_a065_798b2d2809ad -->
+
+    <rdf:Description rdf:about="http://emmo.info/emmo/middle/materials#EMMO_eb77076b_a104_42ac_a065_798b2d2809ad">
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://emmo.info/emmo/middle/properties#EMMO_e1097637_70d2_4895_973f_2396f04fa204"/>
+                <owl:qualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</owl:qualifiedCardinality>
+                <owl:onClass rdf:resource="http://emmc.info/middle/units-extension#EMMO_07de47e0_6bb6_45b9_b55a_4f238efbb105"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://emmo.info/emmo/middle/properties#EMMO_e1097637_70d2_4895_973f_2396f04fa204"/>
+                <owl:qualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</owl:qualifiedCardinality>
+                <owl:onClass rdf:resource="http://emmc.info/middle/units-extension#EMMO_27367073_ed8a_481a_9b07_f836dfe31f7f"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+    </rdf:Description>
+    
+
+
+    <!-- http://emmo.info/emmo/middle/siunits#EMMO_a121bb1d_5225_4c78_809b_0268c3012208 -->
+
+    <rdf:Description rdf:about="http://emmo.info/emmo/middle/siunits#EMMO_a121bb1d_5225_4c78_809b_0268c3012208">
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://emmo.info/emmo/middle/metrology#EMMO_bed1d005_b04e_4a90_94cf_02bc678a8569"/>
+                <owl:allValuesFrom rdf:resource="http://emmc.info/middle/units-extension#EMMO_ed647204_fa50_4599_8f7e_4167cc4d2fb5"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+    </rdf:Description>
+    
+
+
+    <!-- http://emmo.info/emmo/middle/siunits#EMMO_cf3dd6cc_c5d6_4b3d_aef4_82f3b7a361af -->
+
+    <rdf:Description rdf:about="http://emmo.info/emmo/middle/siunits#EMMO_cf3dd6cc_c5d6_4b3d_aef4_82f3b7a361af">
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://emmo.info/emmo/middle/metrology#EMMO_bed1d005_b04e_4a90_94cf_02bc678a8569"/>
+                <owl:allValuesFrom rdf:resource="http://emmc.info/middle/units-extension#EMMO_f9b13cf7_b8c5_4222_aa89_f9ccfa8c7c7c"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+    </rdf:Description>
+</rdf:RDF>
+
+
+
+<!-- Generated by the OWL API (version 4.2.8.20170104-2310) https://github.com/owlcs/owlapi -->
+

--- a/middle/units-extension.owl
+++ b/middle/units-extension.owl
@@ -1,27 +1,24 @@
 <?xml version="1.0"?>
 <rdf:RDF xmlns="http://emmc.info/middle/units-extension#"
      xml:base="http://emmc.info/middle/units-extension"
-     xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
      xmlns:owl="http://www.w3.org/2002/07/owl#"
+     xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
      xmlns:xml="http://www.w3.org/XML/1998/namespace"
      xmlns:xsd="http://www.w3.org/2001/XMLSchema#"
-     xmlns:annotations="http://emmo.info/emmo/top/annotations#"
-     xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">
+     xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+     xmlns:annotations="http://emmo.info/emmo/top/annotations#">
     <owl:Ontology rdf:about="http://emmc.info/middle/units-extension">
         <owl:versionIRI rdf:resource="http://emmc.info/middle/1.0.0-alpha2/units-extension"/>
         <owl:imports rdf:resource="http://emmo.info/emmo/1.0.0-alpha2/middle/materials"/>
         <owl:imports rdf:resource="http://emmo.info/emmo/1.0.0-alpha2/middle/siunits"/>
+        <annotations:EMMO_5525a055_dda5_4556_8b91_f0d22fa676cc>EMMO is released under a Creative Commons license Attribution 4.0 International (CC BY 4.0)
+
+https://creativecommons.org/licenses/by/4.0/legalcode</annotations:EMMO_5525a055_dda5_4556_8b91_f0d22fa676cc>
         <annotations:EMMO_cd5fb112_7ee7_4120_a35d_3ca3e6c3f4ab>Emanuele Ghedini (University of Bologna, IT)
 Gerhard Goldbeck (GCL Ltd, UK)
 Adham Hashibon (Fraunhofer IWM, DE)
 Georg Schmitz (Access, DE)
 Jesper Friis (SINTEF, NO)</annotations:EMMO_cd5fb112_7ee7_4120_a35d_3ca3e6c3f4ab>
-        <annotations:EMMO_5525a055_dda5_4556_8b91_f0d22fa676cc>EMMO is released under a Creative Commons license Attribution 4.0 International (CC BY 4.0)
-
-https://creativecommons.org/licenses/by/4.0/legalcode</annotations:EMMO_5525a055_dda5_4556_8b91_f0d22fa676cc>
-        <owl:versionInfo>The European Materials Modelling Ontology
-
-Version 1.0.0-alpha2</owl:versionInfo>
         <rdfs:comment>Contacts:
 Gerhard Goldbeck
 Goldbeck Consulting Ltd (UK)
@@ -30,12 +27,15 @@ email: gerhard@goldbeck-consulting.com
 Emanuele Ghedini
 University of Bologna (IT)
 email: emanuele.ghedini@unibo.it</rdfs:comment>
-        <rdfs:comment>The EMMO requires FacT++ reasoner plugin in order to visualize all inferences and class hierarchy (ctrl+R hotkey in Protege).</rdfs:comment>
         <rdfs:comment>European Materials and Modelling Ontology (EMMO)
 
 EMMO is a multidisciplinary effort to develop a standard representational framework (the ontology) based on current materials modelling knowledge, including physical sciences, analytical philosophy and information and communication technologies. 
 
 It provides the connection between the physical world, materials characterisation world and materials modelling world.</rdfs:comment>
+        <rdfs:comment>The EMMO requires FacT++ reasoner plugin in order to visualize all inferences and class hierarchy (ctrl+R hotkey in Protege).</rdfs:comment>
+        <owl:versionInfo>The European Materials Modelling Ontology
+
+Version 1.0.0-alpha2</owl:versionInfo>
     </owl:Ontology>
     
 
@@ -105,10 +105,30 @@ It provides the connection between the physical world, materials characterisatio
 
     <owl:Class rdf:about="http://emmc.info/middle/units-extension#EMMO_07de47e0_6bb6_45b9_b55a_4f238efbb105">
         <rdfs:subClassOf rdf:resource="http://emmc.info/middle/units-extension#EMMO_46f30c91_bac0_42ff_8be9_950efe4ee7f1"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://emmo.info/emmo/middle/metrology#EMMO_67fc0a36_8dcb_4ffa_9a43_31074efa3296"/>
+                <owl:allValuesFrom>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://emmo.info/emmo/middle/metrology#EMMO_bed1d005_b04e_4a90_94cf_02bc678a8569"/>
+                        <owl:allValuesFrom rdf:resource="http://emmo.info/emmo/middle/isq#EMMO_3227b821_26a5_4c7c_9c01_5c24483e0bd0"/>
+                    </owl:Restriction>
+                </owl:allValuesFrom>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <annotations:EMMO_6dd685dd_1895_46e4_b227_be9f7d643c25>http://dbpedia.org/page/Atomic_number</annotations:EMMO_6dd685dd_1895_46e4_b227_be9f7d643c25>
         <annotations:EMMO_70fe84ff_99b6_4206_a9fc_9a8931836d84>Number of protons in an atomic nucleus.</annotations:EMMO_70fe84ff_99b6_4206_a9fc_9a8931836d84>
         <annotations:EMMO_fe015383_afb3_44a6_ae86_043628697aa2>https://doi.org/10.1351/goldbook.A00499</annotations:EMMO_fe015383_afb3_44a6_ae86_043628697aa2>
         <rdfs:label xml:lang="en">AtomicNumber</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://emmc.info/middle/units-extension#EMMO_08c83f35_9190_4d0c_afee_6eb1d1eb185f -->
+
+    <owl:Class rdf:about="http://emmc.info/middle/units-extension#EMMO_08c83f35_9190_4d0c_afee_6eb1d1eb185f">
+        <rdfs:subClassOf rdf:resource="http://emmo.info/emmo/middle/metrology#EMMO_9895a1b4_f0a5_4167_ac5e_97db40b8bfcc"/>
+        <rdfs:label xml:lang="en">CurrentPerSquareLengthDimension</rdfs:label>
     </owl:Class>
     
 
@@ -205,6 +225,21 @@ Dispite of that, it is often used in the natural sciences and technology.</rdfs:
     
 
 
+    <!-- http://emmc.info/middle/units-extension#EMMO_285a2832_712d_4156_97bb_125425993143 -->
+
+    <owl:Class rdf:about="http://emmc.info/middle/units-extension#EMMO_285a2832_712d_4156_97bb_125425993143">
+        <owl:equivalentClass>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://emmo.info/emmo/middle/perceptual#EMMO_23b579e1_8088_45b5_9975_064014026c42"/>
+                <owl:hasValue>T-2 L+1 M+1 I-2 Θ0 N0 J0</owl:hasValue>
+            </owl:Restriction>
+        </owl:equivalentClass>
+        <rdfs:subClassOf rdf:resource="http://emmo.info/emmo/middle/metrology#EMMO_9895a1b4_f0a5_4167_ac5e_97db40b8bfcc"/>
+        <rdfs:label xml:lang="en">T-2 L1 M1 I-2 H0 N0 J0</rdfs:label>
+    </owl:Class>
+    
+
+
     <!-- http://emmc.info/middle/units-extension#EMMO_28ef05a7_ecc1_4df6_8116_c53251fbd4a8 -->
 
     <owl:Class rdf:about="http://emmc.info/middle/units-extension#EMMO_28ef05a7_ecc1_4df6_8116_c53251fbd4a8">
@@ -245,6 +280,24 @@ Dispite of that, it is often used in the natural sciences and technology.</rdfs:
     
 
 
+    <!-- http://emmc.info/middle/units-extension#EMMO_3b5c1dc6_9860_4e1a_935f_90152d6b0ab6 -->
+
+    <owl:Class rdf:about="http://emmc.info/middle/units-extension#EMMO_3b5c1dc6_9860_4e1a_935f_90152d6b0ab6">
+        <rdfs:subClassOf rdf:resource="http://emmo.info/emmo/middle/metrology#EMMO_9895a1b4_f0a5_4167_ac5e_97db40b8bfcc"/>
+        <rdfs:label xml:lang="en">T-2 L2 M1 I0 H-1 N-1 J0</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://emmc.info/middle/units-extension#EMMO_41029116_720e_46aa_8f0b_7f6773dc5f2e -->
+
+    <owl:Class rdf:about="http://emmc.info/middle/units-extension#EMMO_41029116_720e_46aa_8f0b_7f6773dc5f2e">
+        <rdfs:subClassOf rdf:resource="http://emmo.info/emmo/middle/metrology#EMMO_9895a1b4_f0a5_4167_ac5e_97db40b8bfcc"/>
+        <rdfs:label xml:lang="en">MassLengthPerTimeDimension</rdfs:label>
+    </owl:Class>
+    
+
+
     <!-- http://emmc.info/middle/units-extension#EMMO_42638511_1ba4_4487_b031_2a4030390c29 -->
 
     <owl:Class rdf:about="http://emmc.info/middle/units-extension#EMMO_42638511_1ba4_4487_b031_2a4030390c29">
@@ -258,7 +311,7 @@ Dispite of that, it is often used in the natural sciences and technology.</rdfs:
     <!-- http://emmc.info/middle/units-extension#EMMO_46f30c91_bac0_42ff_8be9_950efe4ee7f1 -->
 
     <owl:Class rdf:about="http://emmc.info/middle/units-extension#EMMO_46f30c91_bac0_42ff_8be9_950efe4ee7f1">
-        <rdfs:subClassOf rdf:resource="http://emmo.info/emmo/middle/metrology#EMMO_71f6ab56_342c_484b_bbe0_de86b7367cb3"/>
+        <rdfs:subClassOf rdf:resource="http://emmo.info/emmo/middle/isq#EMMO_2946d40b_24a1_47fa_8176_e3f79bb45064"/>
         <annotations:EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9>Derived quantities defined in ISO 80000-10:2019 Quantities and units — Part 10: Atomic and nuclear physics.</annotations:EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9>
         <rdfs:label xml:lang="en">AtomAndNuclearPhysicsDerivedQuantity</rdfs:label>
         <rdfs:seeAlso>https://www.iso.org/obp/ui/#iso:std:iso:80000:-10:ed-2:v1:en</rdfs:seeAlso>
@@ -284,6 +337,15 @@ Dispite of that, it is often used in the natural sciences and technology.</rdfs:
         <annotations:EMMO_c84c6752_6d64_48cc_9500_e54a3c34898d>https://en.wikipedia.org/wiki/Centimetre%E2%80%93gram%E2%80%93second_system_of_units</annotations:EMMO_c84c6752_6d64_48cc_9500_e54a3c34898d>
         <rdfs:comment>CGS is a variant of the metric system.</rdfs:comment>
         <rdfs:label xml:lang="en">CGSUnit</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://emmc.info/middle/units-extension#EMMO_5d8ed88f_fd30_488a_bc0c_fca3a6e65d74 -->
+
+    <owl:Class rdf:about="http://emmc.info/middle/units-extension#EMMO_5d8ed88f_fd30_488a_bc0c_fca3a6e65d74">
+        <rdfs:subClassOf rdf:resource="http://emmo.info/emmo/middle/metrology#EMMO_9895a1b4_f0a5_4167_ac5e_97db40b8bfcc"/>
+        <rdfs:label xml:lang="en">CurrentPerLengthDimension</rdfs:label>
     </owl:Class>
     
 
@@ -367,6 +429,24 @@ Dispite of that, it is often used in the natural sciences and technology.</rdfs:
     
 
 
+    <!-- http://emmc.info/middle/units-extension#EMMO_6d107c94_8284_46ed_8cb5_8484356763d6 -->
+
+    <owl:Class rdf:about="http://emmc.info/middle/units-extension#EMMO_6d107c94_8284_46ed_8cb5_8484356763d6">
+        <rdfs:subClassOf rdf:resource="http://emmo.info/emmo/middle/metrology#EMMO_9895a1b4_f0a5_4167_ac5e_97db40b8bfcc"/>
+        <rdfs:label xml:lang="en">AmountPerCubicLengthDimension</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://emmc.info/middle/units-extension#EMMO_74c40c03_4efb_4fa8_a137_891b465f21a7 -->
+
+    <owl:Class rdf:about="http://emmc.info/middle/units-extension#EMMO_74c40c03_4efb_4fa8_a137_891b465f21a7">
+        <rdfs:subClassOf rdf:resource="http://emmo.info/emmo/middle/metrology#EMMO_9895a1b4_f0a5_4167_ac5e_97db40b8bfcc"/>
+        <rdfs:label xml:lang="en">T2 L-2 M-1 I1 H0 N0 J0</rdfs:label>
+    </owl:Class>
+    
+
+
     <!-- http://emmc.info/middle/units-extension#EMMO_9141801c_c539_4c72_b423_8c74ff6b8f05 -->
 
     <owl:Class rdf:about="http://emmc.info/middle/units-extension#EMMO_9141801c_c539_4c72_b423_8c74ff6b8f05">
@@ -378,6 +458,30 @@ Dispite of that, it is often used in the natural sciences and technology.</rdfs:
         </owl:equivalentClass>
         <rdfs:subClassOf rdf:resource="http://emmo.info/emmo/middle/metrology#EMMO_9895a1b4_f0a5_4167_ac5e_97db40b8bfcc"/>
         <rdfs:label xml:lang="en">CubicLengthDimension</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://emmc.info/middle/units-extension#EMMO_92e9eb29_01be_413f_af50_253acffa61b5 -->
+
+    <owl:Class rdf:about="http://emmc.info/middle/units-extension#EMMO_92e9eb29_01be_413f_af50_253acffa61b5">
+        <rdfs:subClassOf rdf:resource="http://emmo.info/emmo/middle/metrology#EMMO_9895a1b4_f0a5_4167_ac5e_97db40b8bfcc"/>
+        <rdfs:label xml:lang="en">LengthPerSquareTimeDimension</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://emmc.info/middle/units-extension#EMMO_9be889b5_702f_430d_a66d_6f721b5381f5 -->
+
+    <owl:Class rdf:about="http://emmc.info/middle/units-extension#EMMO_9be889b5_702f_430d_a66d_6f721b5381f5">
+        <owl:equivalentClass>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://emmo.info/emmo/middle/perceptual#EMMO_23b579e1_8088_45b5_9975_064014026c42"/>
+                <owl:hasValue>T+3 L-3 M-1 I+2 Θ0 N0 J0</owl:hasValue>
+            </owl:Restriction>
+        </owl:equivalentClass>
+        <rdfs:subClassOf rdf:resource="http://emmo.info/emmo/middle/metrology#EMMO_9895a1b4_f0a5_4167_ac5e_97db40b8bfcc"/>
+        <rdfs:label xml:lang="en">CubicTimeSquareCurrentPerMassCubicLengthDimension</rdfs:label>
     </owl:Class>
     
 
@@ -402,6 +506,39 @@ Dispite of that, it is often used in the natural sciences and technology.</rdfs:
         <annotations:EMMO_70fe84ff_99b6_4206_a9fc_9a8931836d84>A non-SI unit of volume defined as 1 cubic decimetre (dm3),</annotations:EMMO_70fe84ff_99b6_4206_a9fc_9a8931836d84>
         <annotations:EMMO_fe015383_afb3_44a6_ae86_043628697aa2>https://doi.org/10.1351/goldbook.L03594</annotations:EMMO_fe015383_afb3_44a6_ae86_043628697aa2>
         <rdfs:label xml:lang="en">Litre</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://emmc.info/middle/units-extension#EMMO_ad6c76cf_b400_423e_820f_cf0c4e77f455 -->
+
+    <owl:Class rdf:about="http://emmc.info/middle/units-extension#EMMO_ad6c76cf_b400_423e_820f_cf0c4e77f455">
+        <rdfs:subClassOf rdf:resource="http://emmo.info/emmo/middle/siunits#EMMO_f2ca6dd0_0e5f_4392_a92d_cafdae6cfc95"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://emmo.info/emmo/middle/metrology#EMMO_67fc0a36_8dcb_4ffa_9a43_31074efa3296"/>
+                <owl:allValuesFrom>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://emmo.info/emmo/middle/metrology#EMMO_bed1d005_b04e_4a90_94cf_02bc678a8569"/>
+                        <owl:allValuesFrom rdf:resource="http://emmc.info/middle/units-extension#EMMO_3b5c1dc6_9860_4e1a_935f_90152d6b0ab6"/>
+                    </owl:Restriction>
+                </owl:allValuesFrom>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <annotations:EMMO_1f1b164d_ec6a_4faa_8d5e_88bda62316cc>http://physics.nist.gov/cuu/CODATA-Value_MolarGasConstant</annotations:EMMO_1f1b164d_ec6a_4faa_8d5e_88bda62316cc>
+        <annotations:EMMO_6dd685dd_1895_46e4_b227_be9f7d643c25>http://dbpedia.org/page/Gas_constant</annotations:EMMO_6dd685dd_1895_46e4_b227_be9f7d643c25>
+        <annotations:EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9>Equivalent to the Boltzmann constant, but expressed in units of energy per temperature increment per mole (rather than energy per temperature increment per particle).</annotations:EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9>
+        <annotations:EMMO_fe015383_afb3_44a6_ae86_043628697aa2>https://doi.org/10.1351/goldbook.G02579</annotations:EMMO_fe015383_afb3_44a6_ae86_043628697aa2>
+        <rdfs:label xml:lang="en">MolarGasConstant</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://emmc.info/middle/units-extension#EMMO_b12c5b28_b998_4e93_b6e7_73c8a7788060 -->
+
+    <owl:Class rdf:about="http://emmc.info/middle/units-extension#EMMO_b12c5b28_b998_4e93_b6e7_73c8a7788060">
+        <rdfs:subClassOf rdf:resource="http://emmo.info/emmo/middle/metrology#EMMO_9895a1b4_f0a5_4167_ac5e_97db40b8bfcc"/>
+        <rdfs:label xml:lang="en">MassPerSquareLengthDimension</rdfs:label>
     </owl:Class>
     
 
@@ -461,12 +598,50 @@ Wikipedia</annotations:EMMO_70fe84ff_99b6_4206_a9fc_9a8931836d84>
     
 
 
+    <!-- http://emmc.info/middle/units-extension#EMMO_ba380bc6_2bfd_4f11_94c7_b3cbaafd1631 -->
+
+    <owl:Class rdf:about="http://emmc.info/middle/units-extension#EMMO_ba380bc6_2bfd_4f11_94c7_b3cbaafd1631">
+        <rdfs:subClassOf rdf:resource="http://emmo.info/emmo/middle/siunits#EMMO_f2ca6dd0_0e5f_4392_a92d_cafdae6cfc95"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://emmo.info/emmo/middle/metrology#EMMO_67fc0a36_8dcb_4ffa_9a43_31074efa3296"/>
+                <owl:allValuesFrom>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://emmo.info/emmo/middle/metrology#EMMO_bed1d005_b04e_4a90_94cf_02bc678a8569"/>
+                        <owl:allValuesFrom rdf:resource="http://emmc.info/middle/units-extension#EMMO_74c40c03_4efb_4fa8_a137_891b465f21a7"/>
+                    </owl:Restriction>
+                </owl:allValuesFrom>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <annotations:EMMO_1f1b164d_ec6a_4faa_8d5e_88bda62316cc>http://physics.nist.gov/cuu/CODATA-Value_JosephsonConstant</annotations:EMMO_1f1b164d_ec6a_4faa_8d5e_88bda62316cc>
+        <annotations:EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9>Inverse of the magnetic flux quantum.</annotations:EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9>
+        <rdfs:comment>The DBpedia definition (http://dbpedia.org/page/Magnetic_flux_quantum) is outdated as May 20, 2019. It is now an exact quantity.</rdfs:comment>
+        <rdfs:label xml:lang="en">JosephsonConstant</rdfs:label>
+    </owl:Class>
+    
+
+
     <!-- http://emmc.info/middle/units-extension#EMMO_bb39e45f_aeac_4585_8f97_f86213f3f401 -->
 
     <owl:Class rdf:about="http://emmc.info/middle/units-extension#EMMO_bb39e45f_aeac_4585_8f97_f86213f3f401">
         <rdfs:subClassOf rdf:resource="http://emmo.info/emmo/middle/metrology#EMMO_5ebd5e01_0ed3_49a2_a30d_cd05cbe72978"/>
         <annotations:EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9>Dimensionless unit for the fraction of two masses.</annotations:EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9>
         <rdfs:label xml:lang="en">MassPerMassUnit</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://emmc.info/middle/units-extension#EMMO_c0f658fb_bdbc_4221_8659_3afcae921ce7 -->
+
+    <owl:Class rdf:about="http://emmc.info/middle/units-extension#EMMO_c0f658fb_bdbc_4221_8659_3afcae921ce7">
+        <owl:equivalentClass>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://emmo.info/emmo/middle/perceptual#EMMO_23b579e1_8088_45b5_9975_064014026c42"/>
+                <owl:hasValue>T0 L-1 M0 I0 Θ0 N0 J0</owl:hasValue>
+            </owl:Restriction>
+        </owl:equivalentClass>
+        <rdfs:subClassOf rdf:resource="http://emmo.info/emmo/middle/metrology#EMMO_9895a1b4_f0a5_4167_ac5e_97db40b8bfcc"/>
+        <rdfs:label xml:lang="en">PerLengthDimension</rdfs:label>
     </owl:Class>
     
 
@@ -500,7 +675,31 @@ Wikipedia</annotations:EMMO_70fe84ff_99b6_4206_a9fc_9a8931836d84>
     <owl:Class rdf:about="http://emmc.info/middle/units-extension#EMMO_cce78743_ea7c_48f9_9154_5372a60219dc">
         <rdfs:subClassOf rdf:resource="http://emmo.info/emmo/middle/metrology#EMMO_5ebd5e01_0ed3_49a2_a30d_cd05cbe72978"/>
         <annotations:EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9>Dimensionless unit for the fraction of two velocities.</annotations:EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9>
-        <rdfs:label xml:lang="en">VelocityPerVelociryUnit</rdfs:label>
+        <rdfs:label xml:lang="en">SpeedPerSpeedUnit</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://emmc.info/middle/units-extension#EMMO_d0d219cf_2877_4e54_a9d9_912c970cab0e -->
+
+    <owl:Class rdf:about="http://emmc.info/middle/units-extension#EMMO_d0d219cf_2877_4e54_a9d9_912c970cab0e">
+        <owl:equivalentClass>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://emmo.info/emmo/middle/perceptual#EMMO_23b579e1_8088_45b5_9975_064014026c42"/>
+                <owl:hasValue>T+4 L-3 M-1 I+2 Θ0 N0 J0</owl:hasValue>
+            </owl:Restriction>
+        </owl:equivalentClass>
+        <rdfs:subClassOf rdf:resource="http://emmo.info/emmo/middle/metrology#EMMO_9895a1b4_f0a5_4167_ac5e_97db40b8bfcc"/>
+        <rdfs:label xml:lang="en">T4 L-3 M-1 I2 H0 N0 J0</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://emmc.info/middle/units-extension#EMMO_d0d23ff0_36f7_4422_918a_5f21e56923ea -->
+
+    <owl:Class rdf:about="http://emmc.info/middle/units-extension#EMMO_d0d23ff0_36f7_4422_918a_5f21e56923ea">
+        <rdfs:subClassOf rdf:resource="http://emmo.info/emmo/middle/metrology#EMMO_9895a1b4_f0a5_4167_ac5e_97db40b8bfcc"/>
+        <rdfs:label xml:lang="en">MassSquareLengthPerSquareTimeAmountDimension</rdfs:label>
     </owl:Class>
     
 
@@ -534,6 +733,17 @@ Wikipedia</annotations:EMMO_70fe84ff_99b6_4206_a9fc_9a8931836d84>
 
     <owl:Class rdf:about="http://emmc.info/middle/units-extension#EMMO_dc6c8de0_cfc4_4c66_a7dc_8f720e732d54">
         <rdfs:subClassOf rdf:resource="http://emmc.info/middle/units-extension#EMMO_46f30c91_bac0_42ff_8be9_950efe4ee7f1"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://emmo.info/emmo/middle/metrology#EMMO_67fc0a36_8dcb_4ffa_9a43_31074efa3296"/>
+                <owl:allValuesFrom>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://emmo.info/emmo/middle/metrology#EMMO_bed1d005_b04e_4a90_94cf_02bc678a8569"/>
+                        <owl:allValuesFrom rdf:resource="http://emmo.info/emmo/middle/isq#EMMO_3227b821_26a5_4c7c_9c01_5c24483e0bd0"/>
+                    </owl:Restriction>
+                </owl:allValuesFrom>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <annotations:EMMO_70fe84ff_99b6_4206_a9fc_9a8931836d84>Number of nucleons in an atomic nucleus.</annotations:EMMO_70fe84ff_99b6_4206_a9fc_9a8931836d84>
         <rdfs:label xml:lang="en">MassNumber</rdfs:label>
     </owl:Class>
@@ -565,12 +775,40 @@ Wikipedia</annotations:EMMO_70fe84ff_99b6_4206_a9fc_9a8931836d84>
     
 
 
+    <!-- http://emmc.info/middle/units-extension#EMMO_eb561764_276e_413d_a8cb_3a3154fd9bf8 -->
+
+    <owl:Class rdf:about="http://emmc.info/middle/units-extension#EMMO_eb561764_276e_413d_a8cb_3a3154fd9bf8">
+        <rdfs:subClassOf rdf:resource="http://emmo.info/emmo/middle/isq#EMMO_e88f75d6_9a17_4cfc_bdf7_43d7cea5a9a1"/>
+        <rdfs:subClassOf rdf:resource="http://emmo.info/emmo/middle/siunits#EMMO_f2ca6dd0_0e5f_4392_a92d_cafdae6cfc95"/>
+        <annotations:EMMO_1f1b164d_ec6a_4faa_8d5e_88bda62316cc>http://physics.nist.gov/cuu/CODATA-Value_VonKlitzingConstant</annotations:EMMO_1f1b164d_ec6a_4faa_8d5e_88bda62316cc>
+        <annotations:EMMO_70fe84ff_99b6_4206_a9fc_9a8931836d84>The von Klitzing constant is defined as Planck constant divided by the square of the elementary charge.</annotations:EMMO_70fe84ff_99b6_4206_a9fc_9a8931836d84>
+        <rdfs:comment>Resistance quantum.</rdfs:comment>
+        <rdfs:label xml:lang="en">VonKlitzingConstant</rdfs:label>
+    </owl:Class>
+    
+
+
     <!-- http://emmc.info/middle/units-extension#EMMO_ed647204_fa50_4599_8f7e_4167cc4d2fb5 -->
 
     <owl:Class rdf:about="http://emmc.info/middle/units-extension#EMMO_ed647204_fa50_4599_8f7e_4167cc4d2fb5">
         <rdfs:subClassOf rdf:resource="http://emmo.info/emmo/middle/metrology#EMMO_5ebd5e01_0ed3_49a2_a30d_cd05cbe72978"/>
         <annotations:EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9>Dimensionless unit for the fraction of two lengths.</annotations:EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9>
         <rdfs:label xml:lang="en">LengthPerLengthUnit</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://emmc.info/middle/units-extension#EMMO_f688a8d9_4bb2_448d_98d2_11f4268f18f0 -->
+
+    <owl:Class rdf:about="http://emmc.info/middle/units-extension#EMMO_f688a8d9_4bb2_448d_98d2_11f4268f18f0">
+        <owl:equivalentClass>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://emmo.info/emmo/middle/perceptual#EMMO_23b579e1_8088_45b5_9975_064014026c42"/>
+                <owl:hasValue>T0 L-3 M+1 I0 Θ0 N0 J0</owl:hasValue>
+            </owl:Restriction>
+        </owl:equivalentClass>
+        <rdfs:subClassOf rdf:resource="http://emmo.info/emmo/middle/metrology#EMMO_9895a1b4_f0a5_4167_ac5e_97db40b8bfcc"/>
+        <rdfs:label xml:lang="en">MassPerCubicLengthDimension</rdfs:label>
     </owl:Class>
     
 
@@ -655,6 +893,22 @@ Wikipedia</annotations:EMMO_70fe84ff_99b6_4206_a9fc_9a8931836d84>
     
 
 
+    <!-- http://emmo.info/emmo/middle/siunits#EMMO_76cc4efc_231e_42b4_be83_2547681caed6 -->
+
+    <rdf:Description rdf:about="http://emmo.info/emmo/middle/siunits#EMMO_76cc4efc_231e_42b4_be83_2547681caed6">
+        <rdfs:subClassOf rdf:resource="http://emmo.info/middle/units-extension.owl#EMMO_66d01570_36dd_42fd_844d_29b81b029cd5"/>
+    </rdf:Description>
+    
+
+
+    <!-- http://emmo.info/emmo/middle/siunits#EMMO_99296e55_53f7_4333_9e06_760ad175a1b9 -->
+
+    <rdf:Description rdf:about="http://emmo.info/emmo/middle/siunits#EMMO_99296e55_53f7_4333_9e06_760ad175a1b9">
+        <rdfs:subClassOf rdf:resource="http://emmo.info/middle/units-extension.owl#EMMO_81369540_1b0e_471b_9bae_6801af22800e"/>
+    </rdf:Description>
+    
+
+
     <!-- http://emmo.info/emmo/middle/siunits#EMMO_a121bb1d_5225_4c78_809b_0268c3012208 -->
 
     <rdf:Description rdf:about="http://emmo.info/emmo/middle/siunits#EMMO_a121bb1d_5225_4c78_809b_0268c3012208">
@@ -678,9 +932,835 @@ Wikipedia</annotations:EMMO_70fe84ff_99b6_4206_a9fc_9a8931836d84>
             </owl:Restriction>
         </rdfs:subClassOf>
     </rdf:Description>
+    
+
+
+    <!-- http://emmo.info/emmo/middle/siunits#EMMO_ffc7735f_c177_46a4_98e9_a54440d29209 -->
+
+    <rdf:Description rdf:about="http://emmo.info/emmo/middle/siunits#EMMO_ffc7735f_c177_46a4_98e9_a54440d29209">
+        <rdfs:subClassOf rdf:resource="http://emmo.info/middle/units-extension.owl#EMMO_9bbab0be_f9cc_4f46_9f46_0fd271911b79"/>
+    </rdf:Description>
+    
+
+
+    <!-- http://emmo.info/middle/units-extension#EMMO_44fc8c60_7a9c_49af_a046_e1878c88862c -->
+
+    <owl:Class rdf:about="http://emmo.info/middle/units-extension#EMMO_44fc8c60_7a9c_49af_a046_e1878c88862c">
+        <rdfs:subClassOf rdf:resource="http://emmo.info/emmo/middle/isq#EMMO_ed4af7ae_63a2_497e_bb88_2309619ea405"/>
+        <rdfs:subClassOf rdf:resource="http://emmo.info/emmo/middle/metrology#EMMO_3f15d200_c97b_42c8_8ac0_d81d150361e2"/>
+        <annotations:EMMO_1f1b164d_ec6a_4faa_8d5e_88bda62316cc>http://physics.nist.gov/cuu/CODATA-Value_ElectronMass</annotations:EMMO_1f1b164d_ec6a_4faa_8d5e_88bda62316cc>
+        <annotations:EMMO_6dd685dd_1895_46e4_b227_be9f7d643c25>http://dbpedia.org/page/Electron_rest_mass</annotations:EMMO_6dd685dd_1895_46e4_b227_be9f7d643c25>
+        <annotations:EMMO_fe015383_afb3_44a6_ae86_043628697aa2>https://doi.org/10.1351/goldbook.E02008</annotations:EMMO_fe015383_afb3_44a6_ae86_043628697aa2>
+        <rdfs:comment>The rest mass of an electron.</rdfs:comment>
+        <rdfs:label xml:lang="en">ElectronMass</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://emmo.info/middle/units-extension#EMMO_61a32ae9_8200_473a_bd55_59a9899996f4 -->
+
+    <owl:Class rdf:about="http://emmo.info/middle/units-extension#EMMO_61a32ae9_8200_473a_bd55_59a9899996f4">
+        <rdfs:subClassOf rdf:resource="http://emmo.info/emmo/middle/metrology#EMMO_3f15d200_c97b_42c8_8ac0_d81d150361e2"/>
+        <rdfs:subClassOf rdf:resource="http://emmo.info/middle/units-extension.owl#EMMO_0ee5779e_d798_4ee5_9bfe_c392d5bea112"/>
+        <annotations:EMMO_1f1b164d_ec6a_4faa_8d5e_88bda62316cc>http://physics.nist.gov/cuu/CODATA-Value_ElectricConstant</annotations:EMMO_1f1b164d_ec6a_4faa_8d5e_88bda62316cc>
+        <annotations:EMMO_fe015383_afb3_44a6_ae86_043628697aa2>https://doi.org/10.1351/goldbook.P04508</annotations:EMMO_fe015383_afb3_44a6_ae86_043628697aa2>
+        <rdfs:comment>The DBpedia definition (http://dbpedia.org/page/Vacuum_permittivity) is outdated since May 20, 2019. It is now a measured constant.</rdfs:comment>
+        <rdfs:comment>The value of the absolute dielectric permittivity of classical vacuum.</rdfs:comment>
+        <rdfs:label xml:lang="en">VacuumElectricPermittivity</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://emmo.info/middle/units-extension#EMMO_8d689295_7d84_421b_bc01_d5cceb2c2086 -->
+
+    <owl:Class rdf:about="http://emmo.info/middle/units-extension#EMMO_8d689295_7d84_421b_bc01_d5cceb2c2086">
+        <rdfs:subClassOf rdf:resource="http://emmo.info/emmo/middle/isq#EMMO_ed4af7ae_63a2_497e_bb88_2309619ea405"/>
+        <rdfs:subClassOf rdf:resource="http://emmo.info/emmo/middle/metrology#EMMO_3f15d200_c97b_42c8_8ac0_d81d150361e2"/>
+        <annotations:EMMO_1f1b164d_ec6a_4faa_8d5e_88bda62316cc>http://physics.nist.gov/cuu/CODATA-Value_ProtonMass</annotations:EMMO_1f1b164d_ec6a_4faa_8d5e_88bda62316cc>
+        <annotations:EMMO_fe015383_afb3_44a6_ae86_043628697aa2>https://doi.org/10.1351/goldbook.P04914</annotations:EMMO_fe015383_afb3_44a6_ae86_043628697aa2>
+        <rdfs:comment>The rest mass of a proton.</rdfs:comment>
+        <rdfs:label xml:lang="en">ProtonMass</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://emmo.info/middle/units-extension#EMMO_a3c78d6f_ae49_47c8_a634_9b6d86b79382 -->
+
+    <owl:Class rdf:about="http://emmo.info/middle/units-extension#EMMO_a3c78d6f_ae49_47c8_a634_9b6d86b79382">
+        <rdfs:subClassOf rdf:resource="http://emmo.info/emmo/middle/metrology#EMMO_3f15d200_c97b_42c8_8ac0_d81d150361e2"/>
+        <rdfs:subClassOf rdf:resource="http://emmo.info/middle/units-extension.owl#EMMO_d859588d_44dc_4614_bc75_5fcd0058acc8"/>
+        <annotations:EMMO_1f1b164d_ec6a_4faa_8d5e_88bda62316cc>http://physics.nist.gov/cuu/CODATA-Value_RybergConstant</annotations:EMMO_1f1b164d_ec6a_4faa_8d5e_88bda62316cc>
+        <annotations:EMMO_6dd685dd_1895_46e4_b227_be9f7d643c25>http://dbpedia.org/page/Rydberg_constant</annotations:EMMO_6dd685dd_1895_46e4_b227_be9f7d643c25>
+        <annotations:EMMO_fe015383_afb3_44a6_ae86_043628697aa2>https://doi.org/10.1351/goldbook.R05430</annotations:EMMO_fe015383_afb3_44a6_ae86_043628697aa2>
+        <rdfs:comment>The Rydberg constant represents the limiting value of the highest wavenumber (the inverse wavelength) of any photon that can be emitted from the hydrogen atom, or, alternatively, the wavenumber of the lowest-energy photon capable of ionizing the hydrogen atom from its ground state.</rdfs:comment>
+        <rdfs:label xml:lang="en">RybergConstant</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://emmo.info/middle/units-extension#EMMO_d7d2ca25_03e1_4099_9220_c1a58df13ad0 -->
+
+    <owl:Class rdf:about="http://emmo.info/middle/units-extension#EMMO_d7d2ca25_03e1_4099_9220_c1a58df13ad0">
+        <rdfs:subClassOf rdf:resource="http://emmo.info/emmo/middle/metrology#EMMO_3f15d200_c97b_42c8_8ac0_d81d150361e2"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://emmo.info/emmo/middle/metrology#EMMO_67fc0a36_8dcb_4ffa_9a43_31074efa3296"/>
+                <owl:allValuesFrom>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://emmo.info/emmo/middle/metrology#EMMO_bed1d005_b04e_4a90_94cf_02bc678a8569"/>
+                        <owl:allValuesFrom rdf:resource="http://emmo.info/emmo/middle/isq#EMMO_3227b821_26a5_4c7c_9c01_5c24483e0bd0"/>
+                    </owl:Restriction>
+                </owl:allValuesFrom>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <annotations:EMMO_1f1b164d_ec6a_4faa_8d5e_88bda62316cc>http://physics.nist.gov/cuu/CODATA-Value_FineStructureConstant</annotations:EMMO_1f1b164d_ec6a_4faa_8d5e_88bda62316cc>
+        <annotations:EMMO_6dd685dd_1895_46e4_b227_be9f7d643c25>http://dbpedia.org/page/Fine-structure_constant</annotations:EMMO_6dd685dd_1895_46e4_b227_be9f7d643c25>
+        <annotations:EMMO_fe015383_afb3_44a6_ae86_043628697aa2>https://doi.org/10.1351/goldbook.F02389</annotations:EMMO_fe015383_afb3_44a6_ae86_043628697aa2>
+        <rdfs:comment>A fundamental physical constant characterizing the strength of the electromagnetic interaction between elementary charged particles.</rdfs:comment>
+        <rdfs:label xml:lang="en">FineStructureConstant</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://emmo.info/middle/units-extension#EMMO_da831168_975a_41f8_baae_279c298569da -->
+
+    <owl:Class rdf:about="http://emmo.info/middle/units-extension#EMMO_da831168_975a_41f8_baae_279c298569da">
+        <rdfs:subClassOf rdf:resource="http://emmo.info/emmo/middle/metrology#EMMO_3f15d200_c97b_42c8_8ac0_d81d150361e2"/>
+        <annotations:EMMO_1f1b164d_ec6a_4faa_8d5e_88bda62316cc>http://physics.nist.gov/cuu/CODATA-Value_NewtonianConstantOfGravity</annotations:EMMO_1f1b164d_ec6a_4faa_8d5e_88bda62316cc>
+        <annotations:EMMO_6dd685dd_1895_46e4_b227_be9f7d643c25>http://dbpedia.org/page/Gravitational_constant</annotations:EMMO_6dd685dd_1895_46e4_b227_be9f7d643c25>
+        <annotations:EMMO_fe015383_afb3_44a6_ae86_043628697aa2>https://doi.org/10.1351/goldbook.G02695</annotations:EMMO_fe015383_afb3_44a6_ae86_043628697aa2>
+        <rdfs:comment>Physical constant in Newton&apos;s law of gravitation and in Einstein&apos;s general theory of relativity.</rdfs:comment>
+        <rdfs:label xml:lang="en">NewtonianConstantOfGravity</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://emmo.info/middle/units-extension#EMMO_de021e4f_918f_47ef_a67b_11120f56b9d7 -->
+
+    <owl:Class rdf:about="http://emmo.info/middle/units-extension#EMMO_de021e4f_918f_47ef_a67b_11120f56b9d7">
+        <rdfs:subClassOf rdf:resource="http://emmo.info/emmo/middle/metrology#EMMO_3f15d200_c97b_42c8_8ac0_d81d150361e2"/>
+        <rdfs:subClassOf rdf:resource="http://emmo.info/middle/units-extension.owl#EMMO_09663630_1b84_4202_91e6_e641104f579e"/>
+        <annotations:EMMO_1f1b164d_ec6a_4faa_8d5e_88bda62316cc>http://physics.nist.gov/cuu/CODATA-Value_MagneticConstant</annotations:EMMO_1f1b164d_ec6a_4faa_8d5e_88bda62316cc>
+        <rdfs:comment>The DBpedia and UIPAC Gold Book definitions (http://dbpedia.org/page/Vacuum_permeability,  https://doi.org/10.1351/goldbook.P04504) are outdated since May 20, 2019. It is now a measured constant.</rdfs:comment>
+        <rdfs:comment>The value of magnetic permeability in a classical vacuum.</rdfs:comment>
+        <rdfs:label xml:lang="en">VacuumMagneticPermeability</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://emmo.info/middle/units-extension.owl#EMMO_04b3300c_98bd_42dc_a3b5_e6c29d69f1ac -->
+
+    <owl:Class rdf:about="http://emmo.info/middle/units-extension.owl#EMMO_04b3300c_98bd_42dc_a3b5_e6c29d69f1ac">
+        <rdfs:subClassOf rdf:resource="http://emmo.info/emmo/middle/isq#EMMO_2946d40b_24a1_47fa_8176_e3f79bb45064"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://emmo.info/emmo/middle/metrology#EMMO_67fc0a36_8dcb_4ffa_9a43_31074efa3296"/>
+                <owl:allValuesFrom>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://emmo.info/emmo/middle/metrology#EMMO_bed1d005_b04e_4a90_94cf_02bc678a8569"/>
+                        <owl:allValuesFrom rdf:resource="http://emmc.info/middle/units-extension#EMMO_470b044a_3df0_4f58_aa1a_2d6e27a8c928"/>
+                    </owl:Restriction>
+                </owl:allValuesFrom>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <annotations:EMMO_6dd685dd_1895_46e4_b227_be9f7d643c25>http://dbpedia.org/page/Mole_fraction</annotations:EMMO_6dd685dd_1895_46e4_b227_be9f7d643c25>
+        <annotations:EMMO_e55f2d7c_9893_48cd_b4a4_fdf38253bd20>http://www.ontology-of-units-of-measure.org/resource/om-2/AmountOfSubstanceFraction</annotations:EMMO_e55f2d7c_9893_48cd_b4a4_fdf38253bd20>
+        <annotations:EMMO_fe015383_afb3_44a6_ae86_043628697aa2>https://doi.org/10.1351/goldbook.A00296</annotations:EMMO_fe015383_afb3_44a6_ae86_043628697aa2>
+        <rdfs:label xml:lang="en">AmountFraction</rdfs:label>
+        <rdfs:label>MoleFraction</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://emmo.info/middle/units-extension.owl#EMMO_04cc9451_5306_45d0_8554_22cee4d6e785 -->
+
+    <owl:Class rdf:about="http://emmo.info/middle/units-extension.owl#EMMO_04cc9451_5306_45d0_8554_22cee4d6e785">
+        <rdfs:subClassOf rdf:resource="http://emmo.info/emmo/middle/isq#EMMO_2946d40b_24a1_47fa_8176_e3f79bb45064"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://emmo.info/emmo/middle/metrology#EMMO_67fc0a36_8dcb_4ffa_9a43_31074efa3296"/>
+                <owl:allValuesFrom>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://emmo.info/emmo/middle/metrology#EMMO_bed1d005_b04e_4a90_94cf_02bc678a8569"/>
+                        <owl:allValuesFrom rdf:resource="http://emmo.info/emmo/middle/isq#EMMO_585e0ff0_9429_4d3c_b578_58abb1ba21d1"/>
+                    </owl:Restriction>
+                </owl:allValuesFrom>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <annotations:EMMO_6dd685dd_1895_46e4_b227_be9f7d643c25>http://dbpedia.org/page/Inductance</annotations:EMMO_6dd685dd_1895_46e4_b227_be9f7d643c25>
+        <annotations:EMMO_fe015383_afb3_44a6_ae86_043628697aa2>https://doi.org/10.1351/goldbook.M04076</annotations:EMMO_fe015383_afb3_44a6_ae86_043628697aa2>
+        <rdfs:comment>A property of an electrical conductor by which a change in current through it induces an electromotive force in both the conductor itself and in any nearby conductors by mutual inductance.</rdfs:comment>
+        <rdfs:label xml:lang="en">ElectricalInductance</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://emmo.info/middle/units-extension.owl#EMMO_04cf0295_3e8f_4693_a87f_3130d125cf05 -->
+
+    <owl:Class rdf:about="http://emmo.info/middle/units-extension.owl#EMMO_04cf0295_3e8f_4693_a87f_3130d125cf05">
+        <rdfs:subClassOf rdf:resource="http://emmo.info/emmo/middle/isq#EMMO_1f087811_06cb_42d5_90fb_25d0e7e068ef"/>
+        <annotations:EMMO_6dd685dd_1895_46e4_b227_be9f7d643c25>http://dbpedia.org/page/Weight</annotations:EMMO_6dd685dd_1895_46e4_b227_be9f7d643c25>
+        <annotations:EMMO_fe015383_afb3_44a6_ae86_043628697aa2>https://doi.org/10.1351/goldbook.W06668</annotations:EMMO_fe015383_afb3_44a6_ae86_043628697aa2>
+        <rdfs:comment>Force of gravity acting on a body.</rdfs:comment>
+        <rdfs:label xml:lang="en">Weight</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://emmo.info/middle/units-extension.owl#EMMO_06448f64_8db6_4304_8b2c_e785dba82044 -->
+
+    <owl:Class rdf:about="http://emmo.info/middle/units-extension.owl#EMMO_06448f64_8db6_4304_8b2c_e785dba82044">
+        <rdfs:subClassOf rdf:resource="http://emmo.info/emmo/middle/isq#EMMO_2946d40b_24a1_47fa_8176_e3f79bb45064"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://emmo.info/emmo/middle/metrology#EMMO_67fc0a36_8dcb_4ffa_9a43_31074efa3296"/>
+                <owl:allValuesFrom>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://emmo.info/emmo/middle/metrology#EMMO_bed1d005_b04e_4a90_94cf_02bc678a8569"/>
+                        <owl:allValuesFrom rdf:resource="http://emmc.info/middle/units-extension#EMMO_f688a8d9_4bb2_448d_98d2_11f4268f18f0"/>
+                    </owl:Restriction>
+                </owl:allValuesFrom>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <annotations:EMMO_6dd685dd_1895_46e4_b227_be9f7d643c25>http://dbpedia.org/page/Density</annotations:EMMO_6dd685dd_1895_46e4_b227_be9f7d643c25>
+        <annotations:EMMO_fe015383_afb3_44a6_ae86_043628697aa2>https://doi.org/10.1351/goldbook.D01590</annotations:EMMO_fe015383_afb3_44a6_ae86_043628697aa2>
+        <rdfs:comment>Mass per volume.</rdfs:comment>
+        <rdfs:label xml:lang="en">Density</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://emmo.info/middle/units-extension.owl#EMMO_09663630_1b84_4202_91e6_e641104f579e -->
+
+    <owl:Class rdf:about="http://emmo.info/middle/units-extension.owl#EMMO_09663630_1b84_4202_91e6_e641104f579e">
+        <rdfs:subClassOf rdf:resource="http://emmo.info/emmo/middle/isq#EMMO_2946d40b_24a1_47fa_8176_e3f79bb45064"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://emmo.info/emmo/middle/metrology#EMMO_67fc0a36_8dcb_4ffa_9a43_31074efa3296"/>
+                <owl:allValuesFrom>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://emmo.info/emmo/middle/metrology#EMMO_bed1d005_b04e_4a90_94cf_02bc678a8569"/>
+                        <owl:allValuesFrom rdf:resource="http://emmc.info/middle/units-extension#EMMO_285a2832_712d_4156_97bb_125425993143"/>
+                    </owl:Restriction>
+                </owl:allValuesFrom>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <annotations:EMMO_6dd685dd_1895_46e4_b227_be9f7d643c25>http://dbpedia.org/page/Permeability_(electromagnetism)</annotations:EMMO_6dd685dd_1895_46e4_b227_be9f7d643c25>
+        <annotations:EMMO_fe015383_afb3_44a6_ae86_043628697aa2>https://doi.org/10.1351/goldbook.P04503</annotations:EMMO_fe015383_afb3_44a6_ae86_043628697aa2>
+        <rdfs:comment>Measure for how the magnetization of material is affected by the application of an external magnetic field .</rdfs:comment>
+        <rdfs:label xml:lang="en">Permeability</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://emmo.info/middle/units-extension.owl#EMMO_0ee5779e_d798_4ee5_9bfe_c392d5bea112 -->
+
+    <owl:Class rdf:about="http://emmo.info/middle/units-extension.owl#EMMO_0ee5779e_d798_4ee5_9bfe_c392d5bea112">
+        <rdfs:subClassOf rdf:resource="http://emmo.info/emmo/middle/isq#EMMO_2946d40b_24a1_47fa_8176_e3f79bb45064"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://emmo.info/emmo/middle/metrology#EMMO_67fc0a36_8dcb_4ffa_9a43_31074efa3296"/>
+                <owl:allValuesFrom>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://emmo.info/emmo/middle/metrology#EMMO_bed1d005_b04e_4a90_94cf_02bc678a8569"/>
+                        <owl:allValuesFrom rdf:resource="http://emmc.info/middle/units-extension#EMMO_d0d219cf_2877_4e54_a9d9_912c970cab0e"/>
+                    </owl:Restriction>
+                </owl:allValuesFrom>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <annotations:EMMO_6dd685dd_1895_46e4_b227_be9f7d643c25>http://dbpedia.org/page/Permittivity</annotations:EMMO_6dd685dd_1895_46e4_b227_be9f7d643c25>
+        <annotations:EMMO_e55f2d7c_9893_48cd_b4a4_fdf38253bd20>http://www.ontology-of-units-of-measure.org/resource/om-2/Permittivity</annotations:EMMO_e55f2d7c_9893_48cd_b4a4_fdf38253bd20>
+        <annotations:EMMO_fe015383_afb3_44a6_ae86_043628697aa2>https://doi.org/10.1351/goldbook.P04507</annotations:EMMO_fe015383_afb3_44a6_ae86_043628697aa2>
+        <rdfs:comment>Measure for how the polarization of a material is affected by the application of an external electric field.</rdfs:comment>
+        <rdfs:label xml:lang="en">Permittivity</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://emmo.info/middle/units-extension.owl#EMMO_12d4ba9b_2f89_4ea3_b206_cd376f96c875 -->
+
+    <owl:Class rdf:about="http://emmo.info/middle/units-extension.owl#EMMO_12d4ba9b_2f89_4ea3_b206_cd376f96c875">
+        <rdfs:subClassOf rdf:resource="http://emmo.info/emmo/middle/isq#EMMO_31ec09ba_1713_42cb_83c7_b38bf6f9ced2"/>
+        <annotations:EMMO_fe015383_afb3_44a6_ae86_043628697aa2>https://doi.org/10.1351/goldbook.H02752</annotations:EMMO_fe015383_afb3_44a6_ae86_043628697aa2>
+        <rdfs:comment>Heat is energy in transfer to or from a thermodynamic system, by mechanisms other than thermodynamic work or transfer of matter.</rdfs:comment>
+        <rdfs:label xml:lang="en">Heat</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://emmo.info/middle/units-extension.owl#EMMO_16f2fe60_2db7_43ca_8fee_5b3e416bfe87 -->
+
+    <owl:Class rdf:about="http://emmo.info/middle/units-extension.owl#EMMO_16f2fe60_2db7_43ca_8fee_5b3e416bfe87">
+        <rdfs:subClassOf rdf:resource="http://emmo.info/middle/units-extension.owl#EMMO_06448f64_8db6_4304_8b2c_e785dba82044"/>
+        <annotations:EMMO_6dd685dd_1895_46e4_b227_be9f7d643c25>http://dbpedia.org/page/Mass_concentration_(chemistry)</annotations:EMMO_6dd685dd_1895_46e4_b227_be9f7d643c25>
+        <annotations:EMMO_fe015383_afb3_44a6_ae86_043628697aa2>https://doi.org/10.1351/goldbook.M03713</annotations:EMMO_fe015383_afb3_44a6_ae86_043628697aa2>
+        <rdfs:comment>Mass of a constituent divided by the volume of the mixture.</rdfs:comment>
+        <rdfs:label xml:lang="en">MassConcentration</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://emmo.info/middle/units-extension.owl#EMMO_1e7603a7_1365_49b8_b5e5_3711c8e6b904 -->
+
+    <owl:Class rdf:about="http://emmo.info/middle/units-extension.owl#EMMO_1e7603a7_1365_49b8_b5e5_3711c8e6b904">
+        <rdfs:subClassOf rdf:resource="http://emmo.info/emmo/middle/isq#EMMO_2946d40b_24a1_47fa_8176_e3f79bb45064"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://emmo.info/emmo/middle/metrology#EMMO_67fc0a36_8dcb_4ffa_9a43_31074efa3296"/>
+                <owl:allValuesFrom>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://emmo.info/emmo/middle/metrology#EMMO_bed1d005_b04e_4a90_94cf_02bc678a8569"/>
+                        <owl:allValuesFrom rdf:resource="http://emmc.info/middle/units-extension#EMMO_c0f658fb_bdbc_4221_8659_3afcae921ce7"/>
+                    </owl:Restriction>
+                </owl:allValuesFrom>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <annotations:EMMO_6dd685dd_1895_46e4_b227_be9f7d643c25>http://dbpedia.org/page/Vergence</annotations:EMMO_6dd685dd_1895_46e4_b227_be9f7d643c25>
+        <rdfs:comment>In geometrical optics, vergence describes the curvature of optical wavefronts.</rdfs:comment>
+        <rdfs:label xml:lang="en">Vergence</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://emmo.info/middle/units-extension.owl#EMMO_3df10765_f6ff_4c9e_be3d_10b1809d78bd -->
+
+    <owl:Class rdf:about="http://emmo.info/middle/units-extension.owl#EMMO_3df10765_f6ff_4c9e_be3d_10b1809d78bd">
+        <rdfs:subClassOf rdf:resource="http://emmo.info/emmo/middle/isq#EMMO_2946d40b_24a1_47fa_8176_e3f79bb45064"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://emmo.info/emmo/middle/metrology#EMMO_67fc0a36_8dcb_4ffa_9a43_31074efa3296"/>
+                <owl:allValuesFrom>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://emmo.info/emmo/middle/metrology#EMMO_bed1d005_b04e_4a90_94cf_02bc678a8569"/>
+                        <owl:allValuesFrom rdf:resource="http://emmo.info/emmo/middle/isq#EMMO_847f1d9f_205e_46c1_8cb6_a9e479421f88"/>
+                    </owl:Restriction>
+                </owl:allValuesFrom>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <annotations:EMMO_6dd685dd_1895_46e4_b227_be9f7d643c25>http://dbpedia.org/page/Equivalent_dose</annotations:EMMO_6dd685dd_1895_46e4_b227_be9f7d643c25>
+        <rdfs:comment>A dose quantity used in the International Commission on Radiological Protection (ICRP) system of radiological protection.</rdfs:comment>
+        <rdfs:label xml:lang="en">DoseEquivalent</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://emmo.info/middle/units-extension.owl#EMMO_4091d5ec_a4df_42b9_a073_9a090839279f -->
+
+    <owl:Class rdf:about="http://emmo.info/middle/units-extension.owl#EMMO_4091d5ec_a4df_42b9_a073_9a090839279f">
+        <rdfs:subClassOf rdf:resource="http://emmo.info/emmo/middle/isq#EMMO_31ec09ba_1713_42cb_83c7_b38bf6f9ced2"/>
+        <annotations:EMMO_6dd685dd_1895_46e4_b227_be9f7d643c25>http://dbpedia.org/page/Enthalpy</annotations:EMMO_6dd685dd_1895_46e4_b227_be9f7d643c25>
+        <annotations:EMMO_fe015383_afb3_44a6_ae86_043628697aa2>https://doi.org/10.1351/goldbook.E02141</annotations:EMMO_fe015383_afb3_44a6_ae86_043628697aa2>
+        <rdfs:comment>Measurement of energy in a thermodynamic system.</rdfs:comment>
+        <rdfs:label xml:lang="en">Enthalpy</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://emmo.info/middle/units-extension.owl#EMMO_43776fc9_d712_4571_85f0_72183678039a -->
+
+    <owl:Class rdf:about="http://emmo.info/middle/units-extension.owl#EMMO_43776fc9_d712_4571_85f0_72183678039a">
+        <rdfs:subClassOf rdf:resource="http://emmo.info/emmo/middle/isq#EMMO_2946d40b_24a1_47fa_8176_e3f79bb45064"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://emmo.info/emmo/middle/metrology#EMMO_67fc0a36_8dcb_4ffa_9a43_31074efa3296"/>
+                <owl:allValuesFrom>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://emmo.info/emmo/middle/metrology#EMMO_bed1d005_b04e_4a90_94cf_02bc678a8569"/>
+                        <owl:allValuesFrom rdf:resource="http://emmc.info/middle/units-extension#EMMO_41029116_720e_46aa_8f0b_7f6773dc5f2e"/>
+                    </owl:Restriction>
+                </owl:allValuesFrom>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <annotations:EMMO_6dd685dd_1895_46e4_b227_be9f7d643c25>http://dbpedia.org/page/Momentum</annotations:EMMO_6dd685dd_1895_46e4_b227_be9f7d643c25>
+        <annotations:EMMO_fe015383_afb3_44a6_ae86_043628697aa2>https://doi.org/10.1351/goldbook.M04007</annotations:EMMO_fe015383_afb3_44a6_ae86_043628697aa2>
+        <rdfs:comment>Product of mass and velocity.</rdfs:comment>
+        <rdfs:label xml:lang="en">Momentum</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://emmo.info/middle/units-extension.owl#EMMO_5eedba4d_105b_44d8_b1bc_e33606276ea2 -->
+
+    <owl:Class rdf:about="http://emmo.info/middle/units-extension.owl#EMMO_5eedba4d_105b_44d8_b1bc_e33606276ea2">
+        <rdfs:subClassOf rdf:resource="http://emmo.info/emmo/middle/isq#EMMO_2946d40b_24a1_47fa_8176_e3f79bb45064"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://emmo.info/emmo/middle/metrology#EMMO_67fc0a36_8dcb_4ffa_9a43_31074efa3296"/>
+                <owl:allValuesFrom>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://emmo.info/emmo/middle/metrology#EMMO_bed1d005_b04e_4a90_94cf_02bc678a8569"/>
+                        <owl:allValuesFrom rdf:resource="http://emmc.info/middle/units-extension#EMMO_cce78743_ea7c_48f9_9154_5372a60219dc"/>
+                    </owl:Restriction>
+                </owl:allValuesFrom>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <annotations:EMMO_6dd685dd_1895_46e4_b227_be9f7d643c25>http://dbpedia.org/page/Refractive_index</annotations:EMMO_6dd685dd_1895_46e4_b227_be9f7d643c25>
+        <annotations:EMMO_fe015383_afb3_44a6_ae86_043628697aa2>https://doi.org/10.1351/goldbook.R05240</annotations:EMMO_fe015383_afb3_44a6_ae86_043628697aa2>
+        <rdfs:comment>Factor by which the phase velocity of light is reduced in a medium.</rdfs:comment>
+        <rdfs:label xml:lang="en">RefractiveIndex</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://emmo.info/middle/units-extension.owl#EMMO_624d72ee_e676_4470_9434_c22b4190d3d5 -->
+
+    <owl:Class rdf:about="http://emmo.info/middle/units-extension.owl#EMMO_624d72ee_e676_4470_9434_c22b4190d3d5">
+        <rdfs:subClassOf rdf:resource="http://emmo.info/emmo/middle/isq#EMMO_31ec09ba_1713_42cb_83c7_b38bf6f9ced2"/>
+        <annotations:EMMO_6dd685dd_1895_46e4_b227_be9f7d643c25>http://dbpedia.org/page/Heat</annotations:EMMO_6dd685dd_1895_46e4_b227_be9f7d643c25>
+        <annotations:EMMO_6dd685dd_1895_46e4_b227_be9f7d643c25>http://dbpedia.org/page/Work_(physics)</annotations:EMMO_6dd685dd_1895_46e4_b227_be9f7d643c25>
+        <annotations:EMMO_70fe84ff_99b6_4206_a9fc_9a8931836d84>Product of force and displacement.</annotations:EMMO_70fe84ff_99b6_4206_a9fc_9a8931836d84>
+        <annotations:EMMO_fe015383_afb3_44a6_ae86_043628697aa2>https://doi.org/10.1351/goldbook.W06684</annotations:EMMO_fe015383_afb3_44a6_ae86_043628697aa2>
+        <rdfs:label xml:lang="en">Work</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://emmo.info/middle/units-extension.owl#EMMO_66d01570_36dd_42fd_844d_29b81b029cd5 -->
+
+    <owl:Class rdf:about="http://emmo.info/middle/units-extension.owl#EMMO_66d01570_36dd_42fd_844d_29b81b029cd5">
+        <rdfs:subClassOf rdf:resource="http://emmo.info/emmo/middle/isq#EMMO_2946d40b_24a1_47fa_8176_e3f79bb45064"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://emmo.info/emmo/middle/metrology#EMMO_67fc0a36_8dcb_4ffa_9a43_31074efa3296"/>
+                <owl:allValuesFrom>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://emmo.info/emmo/middle/metrology#EMMO_bed1d005_b04e_4a90_94cf_02bc678a8569"/>
+                        <owl:allValuesFrom rdf:resource="http://emmo.info/emmo/middle/isq#EMMO_501f9b3a_c469_48f7_9281_2e6a8d805d7a"/>
+                    </owl:Restriction>
+                </owl:allValuesFrom>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <annotations:EMMO_6dd685dd_1895_46e4_b227_be9f7d643c25>http://dbpedia.org/page/Angular_momentum</annotations:EMMO_6dd685dd_1895_46e4_b227_be9f7d643c25>
+        <annotations:EMMO_fe015383_afb3_44a6_ae86_043628697aa2>https://doi.org/10.1351/goldbook.A00353</annotations:EMMO_fe015383_afb3_44a6_ae86_043628697aa2>
+        <rdfs:comment>Measure of the extent and direction an object rotates about a reference point.</rdfs:comment>
+        <rdfs:label xml:lang="en">AngularMomentum</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://emmo.info/middle/units-extension.owl#EMMO_79a02de5_b884_4eab_bc18_f67997d597a2 -->
+
+    <owl:Class rdf:about="http://emmo.info/middle/units-extension.owl#EMMO_79a02de5_b884_4eab_bc18_f67997d597a2">
+        <rdfs:subClassOf rdf:resource="http://emmo.info/emmo/middle/isq#EMMO_e88f75d6_9a17_4cfc_bdf7_43d7cea5a9a1"/>
+        <annotations:EMMO_6dd685dd_1895_46e4_b227_be9f7d643c25>http://dbpedia.org/page/Electrical_impedance</annotations:EMMO_6dd685dd_1895_46e4_b227_be9f7d643c25>
+        <rdfs:comment>Measure of the opposition that a circuit presents to a current when a voltage is applied.</rdfs:comment>
+        <rdfs:label xml:lang="en">ElectricalImpedance</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://emmo.info/middle/units-extension.owl#EMMO_7c055d65_2929_40e1_af4f_4bf10995ad50 -->
+
+    <owl:Class rdf:about="http://emmo.info/middle/units-extension.owl#EMMO_7c055d65_2929_40e1_af4f_4bf10995ad50">
+        <rdfs:subClassOf rdf:resource="http://emmo.info/emmo/middle/isq#EMMO_2946d40b_24a1_47fa_8176_e3f79bb45064"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://emmo.info/emmo/middle/metrology#EMMO_67fc0a36_8dcb_4ffa_9a43_31074efa3296"/>
+                <owl:allValuesFrom>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://emmo.info/emmo/middle/metrology#EMMO_bed1d005_b04e_4a90_94cf_02bc678a8569"/>
+                        <owl:allValuesFrom rdf:resource="http://emmc.info/middle/units-extension#EMMO_bb39e45f_aeac_4585_8f97_f86213f3f401"/>
+                    </owl:Restriction>
+                </owl:allValuesFrom>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <annotations:EMMO_6dd685dd_1895_46e4_b227_be9f7d643c25>http://dbpedia.org/page/Mass_fraction_(chemistry)</annotations:EMMO_6dd685dd_1895_46e4_b227_be9f7d643c25>
+        <annotations:EMMO_e55f2d7c_9893_48cd_b4a4_fdf38253bd20>http://www.ontology-of-units-of-measure.org/resource/om-2/MassFraction</annotations:EMMO_e55f2d7c_9893_48cd_b4a4_fdf38253bd20>
+        <annotations:EMMO_fe015383_afb3_44a6_ae86_043628697aa2>https://doi.org/10.1351/goldbook.M03722</annotations:EMMO_fe015383_afb3_44a6_ae86_043628697aa2>
+        <rdfs:comment>Mass of a constituent divided by the total mass of all constituents in the mixture.</rdfs:comment>
+        <rdfs:label xml:lang="en">MassFraction</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://emmo.info/middle/units-extension.owl#EMMO_7c8007b0_58a7_4486_bf1c_4772852caca0 -->
+
+    <owl:Class rdf:about="http://emmo.info/middle/units-extension.owl#EMMO_7c8007b0_58a7_4486_bf1c_4772852caca0">
+        <rdfs:subClassOf rdf:resource="http://emmo.info/emmo/middle/isq#EMMO_2946d40b_24a1_47fa_8176_e3f79bb45064"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://emmo.info/emmo/middle/metrology#EMMO_67fc0a36_8dcb_4ffa_9a43_31074efa3296"/>
+                <owl:allValuesFrom>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://emmo.info/emmo/middle/metrology#EMMO_bed1d005_b04e_4a90_94cf_02bc678a8569"/>
+                        <owl:allValuesFrom rdf:resource="http://emmc.info/middle/units-extension#EMMO_08c83f35_9190_4d0c_afee_6eb1d1eb185f"/>
+                    </owl:Restriction>
+                </owl:allValuesFrom>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <annotations:EMMO_6dd685dd_1895_46e4_b227_be9f7d643c25>http://dbpedia.org/page/Current_density</annotations:EMMO_6dd685dd_1895_46e4_b227_be9f7d643c25>
+        <annotations:EMMO_fe015383_afb3_44a6_ae86_043628697aa2>https://doi.org/10.1351/goldbook.E01928</annotations:EMMO_fe015383_afb3_44a6_ae86_043628697aa2>
+        <rdfs:comment>Electric current divided by the cross-sectional area it is passing through.</rdfs:comment>
+        <rdfs:label xml:lang="en">CurrentDensity</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://emmo.info/middle/units-extension.owl#EMMO_81369540_1b0e_471b_9bae_6801af22800e -->
+
+    <owl:Class rdf:about="http://emmo.info/middle/units-extension.owl#EMMO_81369540_1b0e_471b_9bae_6801af22800e">
+        <rdfs:subClassOf rdf:resource="http://emmo.info/emmo/middle/isq#EMMO_2946d40b_24a1_47fa_8176_e3f79bb45064"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://emmo.info/emmo/middle/metrology#EMMO_67fc0a36_8dcb_4ffa_9a43_31074efa3296"/>
+                <owl:allValuesFrom>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://emmo.info/emmo/middle/metrology#EMMO_bed1d005_b04e_4a90_94cf_02bc678a8569"/>
+                        <owl:allValuesFrom rdf:resource="http://emmo.info/emmo/middle/isq#EMMO_4f5c7c54_1c63_4d17_b12b_ea0792c2b187"/>
+                    </owl:Restriction>
+                </owl:allValuesFrom>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <annotations:EMMO_6dd685dd_1895_46e4_b227_be9f7d643c25>http://dbpedia.org/page/Speed</annotations:EMMO_6dd685dd_1895_46e4_b227_be9f7d643c25>
+        <annotations:EMMO_e55f2d7c_9893_48cd_b4a4_fdf38253bd20>http://www.ontology-of-units-of-measure.org/resource/om-2/Speed</annotations:EMMO_e55f2d7c_9893_48cd_b4a4_fdf38253bd20>
+        <annotations:EMMO_fe015383_afb3_44a6_ae86_043628697aa2>https://doi.org/10.1351/goldbook.S05852</annotations:EMMO_fe015383_afb3_44a6_ae86_043628697aa2>
+        <rdfs:comment>Length per unit time. 
+
+Speed in the absolute value of the velocity.</rdfs:comment>
+        <rdfs:label xml:lang="en">Speed</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://emmo.info/middle/units-extension.owl#EMMO_88fc5d1b_d3ab_4626_b24c_915ebe7400ca -->
+
+    <owl:Class rdf:about="http://emmo.info/middle/units-extension.owl#EMMO_88fc5d1b_d3ab_4626_b24c_915ebe7400ca">
+        <rdfs:subClassOf rdf:resource="http://emmo.info/emmo/middle/isq#EMMO_2946d40b_24a1_47fa_8176_e3f79bb45064"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://emmo.info/emmo/middle/metrology#EMMO_67fc0a36_8dcb_4ffa_9a43_31074efa3296"/>
+                <owl:allValuesFrom>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://emmo.info/emmo/middle/metrology#EMMO_bed1d005_b04e_4a90_94cf_02bc678a8569"/>
+                        <owl:allValuesFrom rdf:resource="http://emmc.info/middle/units-extension#EMMO_d0d23ff0_36f7_4422_918a_5f21e56923ea"/>
+                    </owl:Restriction>
+                </owl:allValuesFrom>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <annotations:EMMO_6dd685dd_1895_46e4_b227_be9f7d643c25>http://dbpedia.org/page/Chemical_potential</annotations:EMMO_6dd685dd_1895_46e4_b227_be9f7d643c25>
+        <annotations:EMMO_fe015383_afb3_44a6_ae86_043628697aa2>https://doi.org/10.1351/goldbook.C01032</annotations:EMMO_fe015383_afb3_44a6_ae86_043628697aa2>
+        <rdfs:comment>Energy per unit change in amount of substance.</rdfs:comment>
+        <rdfs:label xml:lang="en">ChemicalPotential</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://emmo.info/middle/units-extension.owl#EMMO_92b2fb85_2143_4bc7_bbca_df3e6944bfc1 -->
+
+    <owl:Class rdf:about="http://emmo.info/middle/units-extension.owl#EMMO_92b2fb85_2143_4bc7_bbca_df3e6944bfc1">
+        <rdfs:subClassOf rdf:resource="http://emmo.info/emmo/middle/isq#EMMO_e88f75d6_9a17_4cfc_bdf7_43d7cea5a9a1"/>
+        <annotations:EMMO_6dd685dd_1895_46e4_b227_be9f7d643c25>http://dbpedia.org/page/Electrical_reactance</annotations:EMMO_6dd685dd_1895_46e4_b227_be9f7d643c25>
+        <rdfs:comment>The opposition of a circuit element to a change in current or voltage, due to that element&apos;s inductance or capacitance.</rdfs:comment>
+        <rdfs:label xml:lang="en">ElectricalReactance</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://emmo.info/middle/units-extension.owl#EMMO_96f39f77_44dc_491b_8fa7_30d887fe0890 -->
+
+    <owl:Class rdf:about="http://emmo.info/middle/units-extension.owl#EMMO_96f39f77_44dc_491b_8fa7_30d887fe0890">
+        <rdfs:subClassOf rdf:resource="http://emmo.info/emmo/middle/isq#EMMO_2946d40b_24a1_47fa_8176_e3f79bb45064"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://emmo.info/emmo/middle/metrology#EMMO_67fc0a36_8dcb_4ffa_9a43_31074efa3296"/>
+                <owl:allValuesFrom>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://emmo.info/emmo/middle/metrology#EMMO_bed1d005_b04e_4a90_94cf_02bc678a8569"/>
+                        <owl:allValuesFrom rdf:resource="http://emmc.info/middle/units-extension#EMMO_33433bb1_c68f_45ee_a466_f01e2c57b214"/>
+                    </owl:Restriction>
+                </owl:allValuesFrom>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <annotations:EMMO_6dd685dd_1895_46e4_b227_be9f7d643c25>http://dbpedia.org/page/Area</annotations:EMMO_6dd685dd_1895_46e4_b227_be9f7d643c25>
+        <annotations:EMMO_fe015383_afb3_44a6_ae86_043628697aa2>https://doi.org/10.1351/goldbook.A00429</annotations:EMMO_fe015383_afb3_44a6_ae86_043628697aa2>
+        <rdfs:comment>Extent of a surface.</rdfs:comment>
+        <rdfs:label xml:lang="en">Area</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://emmo.info/middle/units-extension.owl#EMMO_97589322_710c_4af4_9431_1e5027f2be42 -->
+
+    <owl:Class rdf:about="http://emmo.info/middle/units-extension.owl#EMMO_97589322_710c_4af4_9431_1e5027f2be42">
+        <rdfs:subClassOf rdf:resource="http://emmo.info/emmo/middle/isq#EMMO_2946d40b_24a1_47fa_8176_e3f79bb45064"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://emmo.info/emmo/middle/metrology#EMMO_67fc0a36_8dcb_4ffa_9a43_31074efa3296"/>
+                <owl:allValuesFrom>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://emmo.info/emmo/middle/metrology#EMMO_bed1d005_b04e_4a90_94cf_02bc678a8569"/>
+                        <owl:allValuesFrom rdf:resource="http://emmo.info/emmo/middle/isq#EMMO_668e6ead_1530_40cc_ad5e_24b880edff50"/>
+                    </owl:Restriction>
+                </owl:allValuesFrom>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <annotations:EMMO_6dd685dd_1895_46e4_b227_be9f7d643c25>http://dbpedia.org/page/Luminance</annotations:EMMO_6dd685dd_1895_46e4_b227_be9f7d643c25>
+        <annotations:EMMO_fe015383_afb3_44a6_ae86_043628697aa2>https://doi.org/10.1351/goldbook.L03640</annotations:EMMO_fe015383_afb3_44a6_ae86_043628697aa2>
+        <rdfs:comment>a photometric measure of the luminous intensity per unit area of light travelling in a given direction.</rdfs:comment>
+        <rdfs:label xml:lang="en">Luminance</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://emmo.info/middle/units-extension.owl#EMMO_9bbab0be_f9cc_4f46_9f46_0fd271911b79 -->
+
+    <owl:Class rdf:about="http://emmo.info/middle/units-extension.owl#EMMO_9bbab0be_f9cc_4f46_9f46_0fd271911b79">
+        <rdfs:subClassOf rdf:resource="http://emmo.info/emmo/middle/isq#EMMO_2946d40b_24a1_47fa_8176_e3f79bb45064"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://emmo.info/emmo/middle/metrology#EMMO_67fc0a36_8dcb_4ffa_9a43_31074efa3296"/>
+                <owl:allValuesFrom>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://emmo.info/emmo/middle/metrology#EMMO_bed1d005_b04e_4a90_94cf_02bc678a8569"/>
+                        <owl:allValuesFrom rdf:resource="http://emmo.info/emmo/middle/isq#EMMO_3ecff38b_b3cf_4a78_b49f_8580abf8715b"/>
+                    </owl:Restriction>
+                </owl:allValuesFrom>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <annotations:EMMO_6dd685dd_1895_46e4_b227_be9f7d643c25>http://dbpedia.org/page/Entropy</annotations:EMMO_6dd685dd_1895_46e4_b227_be9f7d643c25>
+        <annotations:EMMO_fe015383_afb3_44a6_ae86_043628697aa2>https://doi.org/10.1351/goldbook.E02149</annotations:EMMO_fe015383_afb3_44a6_ae86_043628697aa2>
+        <rdfs:comment>Logarithmic measure of the number of available states of a system.</rdfs:comment>
+        <rdfs:comment>May also be referred to as a measure of order of  a system.</rdfs:comment>
+        <rdfs:label xml:lang="en">Entropy</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://emmo.info/middle/units-extension.owl#EMMO_afea89af_ef16_4bdb_99d5_f3b2f4c85a6c -->
+
+    <owl:Class rdf:about="http://emmo.info/middle/units-extension.owl#EMMO_afea89af_ef16_4bdb_99d5_f3b2f4c85a6c">
+        <rdfs:subClassOf rdf:resource="http://emmo.info/emmo/middle/isq#EMMO_2946d40b_24a1_47fa_8176_e3f79bb45064"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://emmo.info/emmo/middle/metrology#EMMO_67fc0a36_8dcb_4ffa_9a43_31074efa3296"/>
+                <owl:allValuesFrom>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://emmo.info/emmo/middle/metrology#EMMO_bed1d005_b04e_4a90_94cf_02bc678a8569"/>
+                        <owl:allValuesFrom rdf:resource="http://emmc.info/middle/units-extension#EMMO_b12c5b28_b998_4e93_b6e7_73c8a7788060"/>
+                    </owl:Restriction>
+                </owl:allValuesFrom>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <annotations:EMMO_6dd685dd_1895_46e4_b227_be9f7d643c25>http://dbpedia.org/page/Area_density</annotations:EMMO_6dd685dd_1895_46e4_b227_be9f7d643c25>
+        <annotations:EMMO_fe015383_afb3_44a6_ae86_043628697aa2>https://doi.org/10.1351/goldbook.S06167</annotations:EMMO_fe015383_afb3_44a6_ae86_043628697aa2>
+        <rdfs:comment>Mass per unit area.</rdfs:comment>
+        <rdfs:label xml:lang="en">AreaDensity</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://emmo.info/middle/units-extension.owl#EMMO_b4895f75_41c8_4fd9_b6d6_4d5f7c99c423 -->
+
+    <owl:Class rdf:about="http://emmo.info/middle/units-extension.owl#EMMO_b4895f75_41c8_4fd9_b6d6_4d5f7c99c423">
+        <rdfs:subClassOf rdf:resource="http://emmo.info/emmo/middle/isq#EMMO_2946d40b_24a1_47fa_8176_e3f79bb45064"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://emmo.info/emmo/middle/metrology#EMMO_67fc0a36_8dcb_4ffa_9a43_31074efa3296"/>
+                <owl:allValuesFrom>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://emmo.info/emmo/middle/metrology#EMMO_bed1d005_b04e_4a90_94cf_02bc678a8569"/>
+                        <owl:allValuesFrom rdf:resource="http://emmc.info/middle/units-extension#EMMO_5d8ed88f_fd30_488a_bc0c_fca3a6e65d74"/>
+                    </owl:Restriction>
+                </owl:allValuesFrom>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <annotations:EMMO_6dd685dd_1895_46e4_b227_be9f7d643c25>http://dbpedia.org/page/Magnetic_field</annotations:EMMO_6dd685dd_1895_46e4_b227_be9f7d643c25>
+        <annotations:EMMO_fe015383_afb3_44a6_ae86_043628697aa2>https://doi.org/10.1351/goldbook.M03683</annotations:EMMO_fe015383_afb3_44a6_ae86_043628697aa2>
+        <rdfs:comment>Strength of a magnetic field. Commonly denoted H.</rdfs:comment>
+        <rdfs:label xml:lang="en">MagneticFieldStrength</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://emmo.info/middle/units-extension.owl#EMMO_bd67d149_24c2_4bc9_833a_c2bc26f98fd3 -->
+
+    <owl:Class rdf:about="http://emmo.info/middle/units-extension.owl#EMMO_bd67d149_24c2_4bc9_833a_c2bc26f98fd3">
+        <rdfs:subClassOf rdf:resource="http://emmo.info/emmo/middle/isq#EMMO_2946d40b_24a1_47fa_8176_e3f79bb45064"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://emmo.info/emmo/middle/metrology#EMMO_67fc0a36_8dcb_4ffa_9a43_31074efa3296"/>
+                <owl:allValuesFrom>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://emmo.info/emmo/middle/metrology#EMMO_bed1d005_b04e_4a90_94cf_02bc678a8569"/>
+                        <owl:allValuesFrom rdf:resource="http://emmo.info/emmo/middle/isq#EMMO_ce7d4720_aa20_4a8c_93e8_df41a35b6723"/>
+                    </owl:Restriction>
+                </owl:allValuesFrom>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <annotations:EMMO_fe015383_afb3_44a6_ae86_043628697aa2>https://doi.org/10.1351/goldbook.C00881</annotations:EMMO_fe015383_afb3_44a6_ae86_043628697aa2>
+        <rdfs:comment>Increase in the rate of reaction of a specified chemical reaction that an enzyme produces in a specific assay system.</rdfs:comment>
+        <rdfs:label xml:lang="en">CatalyticActivity</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://emmo.info/middle/units-extension.owl#EMMO_cde4368c_1d4d_4c94_8548_604749523c6d -->
+
+    <owl:Class rdf:about="http://emmo.info/middle/units-extension.owl#EMMO_cde4368c_1d4d_4c94_8548_604749523c6d">
+        <rdfs:subClassOf rdf:resource="http://emmo.info/emmo/middle/isq#EMMO_2946d40b_24a1_47fa_8176_e3f79bb45064"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://emmo.info/emmo/middle/metrology#EMMO_67fc0a36_8dcb_4ffa_9a43_31074efa3296"/>
+                <owl:allValuesFrom>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://emmo.info/emmo/middle/metrology#EMMO_bed1d005_b04e_4a90_94cf_02bc678a8569"/>
+                        <owl:allValuesFrom rdf:resource="http://emmc.info/middle/units-extension#EMMO_9be889b5_702f_430d_a66d_6f721b5381f5"/>
+                    </owl:Restriction>
+                </owl:allValuesFrom>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <annotations:EMMO_6dd685dd_1895_46e4_b227_be9f7d643c25>http://dbpedia.org/page/Electrical_resistivity_and_conductivity</annotations:EMMO_6dd685dd_1895_46e4_b227_be9f7d643c25>
+        <annotations:EMMO_fe015383_afb3_44a6_ae86_043628697aa2>https://doi.org/10.1351/goldbook.C01245</annotations:EMMO_fe015383_afb3_44a6_ae86_043628697aa2>
+        <rdfs:comment>Measure of a material&apos;s ability to conduct an electric current. 
+
+Conductivity is equeal to the resiprocal of resistivity.</rdfs:comment>
+        <rdfs:label xml:lang="en">ElectricalConductivity</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://emmo.info/middle/units-extension.owl#EMMO_d1917609_db5e_4b8a_9b76_ef1d6f860a81 -->
+
+    <owl:Class rdf:about="http://emmo.info/middle/units-extension.owl#EMMO_d1917609_db5e_4b8a_9b76_ef1d6f860a81">
+        <rdfs:subClassOf rdf:resource="http://emmo.info/emmo/middle/isq#EMMO_50a44256_9dc5_434b_bad4_74a4d9a29989"/>
+        <annotations:EMMO_6dd685dd_1895_46e4_b227_be9f7d643c25>http://dbpedia.org/page/Stress_(mechanics)</annotations:EMMO_6dd685dd_1895_46e4_b227_be9f7d643c25>
+        <rdfs:comment>Force per unit oriented surface area .</rdfs:comment>
+        <rdfs:comment>Measure of the internal forces that neighboring particles of a continuous material exert on each other.</rdfs:comment>
+        <rdfs:label xml:lang="en">Stress</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://emmo.info/middle/units-extension.owl#EMMO_d5be1faf_0c56_4f5a_9b78_581e6dee949f -->
+
+    <owl:Class rdf:about="http://emmo.info/middle/units-extension.owl#EMMO_d5be1faf_0c56_4f5a_9b78_581e6dee949f">
+        <rdfs:subClassOf rdf:resource="http://emmo.info/emmo/middle/isq#EMMO_2946d40b_24a1_47fa_8176_e3f79bb45064"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://emmo.info/emmo/middle/metrology#EMMO_67fc0a36_8dcb_4ffa_9a43_31074efa3296"/>
+                <owl:allValuesFrom>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://emmo.info/emmo/middle/metrology#EMMO_bed1d005_b04e_4a90_94cf_02bc678a8569"/>
+                        <owl:allValuesFrom rdf:resource="http://emmc.info/middle/units-extension#EMMO_6d107c94_8284_46ed_8cb5_8484356763d6"/>
+                    </owl:Restriction>
+                </owl:allValuesFrom>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <annotations:EMMO_6dd685dd_1895_46e4_b227_be9f7d643c25>http://dbpedia.org/page/Molar_concentration</annotations:EMMO_6dd685dd_1895_46e4_b227_be9f7d643c25>
+        <annotations:EMMO_fe015383_afb3_44a6_ae86_043628697aa2>https://doi.org/10.1351/goldbook.A00295</annotations:EMMO_fe015383_afb3_44a6_ae86_043628697aa2>
+        <rdfs:comment>Also called &quot;molar concentration&quot; or &quot;amount concentration&quot; or &quot;molarity&quot;.</rdfs:comment>
+        <rdfs:comment>Molarity</rdfs:comment>
+        <rdfs:comment>The amount of a constituent divided by the volume of the mixture.</rdfs:comment>
+        <rdfs:label>AmountConcentration</rdfs:label>
+        <rdfs:label xml:lang="en">Concentration</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://emmo.info/middle/units-extension.owl#EMMO_d859588d_44dc_4614_bc75_5fcd0058acc8 -->
+
+    <owl:Class rdf:about="http://emmo.info/middle/units-extension.owl#EMMO_d859588d_44dc_4614_bc75_5fcd0058acc8">
+        <rdfs:subClassOf rdf:resource="http://emmo.info/emmo/middle/isq#EMMO_2946d40b_24a1_47fa_8176_e3f79bb45064"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://emmo.info/emmo/middle/metrology#EMMO_67fc0a36_8dcb_4ffa_9a43_31074efa3296"/>
+                <owl:allValuesFrom>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://emmo.info/emmo/middle/metrology#EMMO_bed1d005_b04e_4a90_94cf_02bc678a8569"/>
+                        <owl:allValuesFrom rdf:resource="http://emmc.info/middle/units-extension#EMMO_c0f658fb_bdbc_4221_8659_3afcae921ce7"/>
+                    </owl:Restriction>
+                </owl:allValuesFrom>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <annotations:EMMO_6dd685dd_1895_46e4_b227_be9f7d643c25>http://dbpedia.org/page/Wavenumber</annotations:EMMO_6dd685dd_1895_46e4_b227_be9f7d643c25>
+        <annotations:EMMO_e55f2d7c_9893_48cd_b4a4_fdf38253bd20>http://www.ontology-of-units-of-measure.org/resource/om-2/Wavenumber</annotations:EMMO_e55f2d7c_9893_48cd_b4a4_fdf38253bd20>
+        <annotations:EMMO_fe015383_afb3_44a6_ae86_043628697aa2>https://doi.org/10.1351/goldbook.W06664</annotations:EMMO_fe015383_afb3_44a6_ae86_043628697aa2>
+        <rdfs:comment>The number of waves per unit length along the direction of propagation.</rdfs:comment>
+        <rdfs:label xml:lang="en">Wavenumber</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://emmo.info/middle/units-extension.owl#EMMO_e150fa8d_06dc_4bb8_bf95_04e2aea529c1 -->
+
+    <owl:Class rdf:about="http://emmo.info/middle/units-extension.owl#EMMO_e150fa8d_06dc_4bb8_bf95_04e2aea529c1">
+        <rdfs:subClassOf rdf:resource="http://emmo.info/emmo/middle/isq#EMMO_2946d40b_24a1_47fa_8176_e3f79bb45064"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://emmo.info/emmo/middle/metrology#EMMO_67fc0a36_8dcb_4ffa_9a43_31074efa3296"/>
+                <owl:allValuesFrom>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://emmo.info/emmo/middle/metrology#EMMO_bed1d005_b04e_4a90_94cf_02bc678a8569"/>
+                        <owl:allValuesFrom rdf:resource="http://emmo.info/emmo/middle/isq#EMMO_f6070071_d054_4b17_9d2d_f446f7147d0f"/>
+                    </owl:Restriction>
+                </owl:allValuesFrom>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <annotations:EMMO_6dd685dd_1895_46e4_b227_be9f7d643c25>http://dbpedia.org/page/Electrical_resistivity_and_conductivity</annotations:EMMO_6dd685dd_1895_46e4_b227_be9f7d643c25>
+        <annotations:EMMO_fe015383_afb3_44a6_ae86_043628697aa2>https://doi.org/10.1351/goldbook.R05316</annotations:EMMO_fe015383_afb3_44a6_ae86_043628697aa2>
+        <rdfs:comment>Electric field strength divided by the current density.</rdfs:comment>
+        <rdfs:label xml:lang="en">ElectricalResistivity</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://emmo.info/middle/units-extension.owl#EMMO_e37ac288_aa60_415a_8cb7_c375724ac8e1 -->
+
+    <owl:Class rdf:about="http://emmo.info/middle/units-extension.owl#EMMO_e37ac288_aa60_415a_8cb7_c375724ac8e1">
+        <rdfs:subClassOf rdf:resource="http://emmo.info/emmo/middle/isq#EMMO_2946d40b_24a1_47fa_8176_e3f79bb45064"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://emmo.info/emmo/middle/metrology#EMMO_67fc0a36_8dcb_4ffa_9a43_31074efa3296"/>
+                <owl:allValuesFrom>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://emmo.info/emmo/middle/metrology#EMMO_bed1d005_b04e_4a90_94cf_02bc678a8569"/>
+                        <owl:allValuesFrom rdf:resource="http://emmc.info/middle/units-extension#EMMO_92e9eb29_01be_413f_af50_253acffa61b5"/>
+                    </owl:Restriction>
+                </owl:allValuesFrom>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <annotations:EMMO_6dd685dd_1895_46e4_b227_be9f7d643c25>http://dbpedia.org/page/Acceleration</annotations:EMMO_6dd685dd_1895_46e4_b227_be9f7d643c25>
+        <annotations:EMMO_fe015383_afb3_44a6_ae86_043628697aa2>https://doi.org/10.1351/goldbook.A00051</annotations:EMMO_fe015383_afb3_44a6_ae86_043628697aa2>
+        <rdfs:comment>Derivative of velocity with respect to time.</rdfs:comment>
+        <rdfs:label xml:lang="en">Acceleration</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://emmo.info/middle/units-extension.owl#EMMO_e46f3f24_c2ec_4552_8dd4_cfc5c0a89c09 -->
+
+    <owl:Class rdf:about="http://emmo.info/middle/units-extension.owl#EMMO_e46f3f24_c2ec_4552_8dd4_cfc5c0a89c09">
+        <rdfs:subClassOf rdf:resource="http://emmo.info/emmo/middle/isq#EMMO_09b9021b_f97b_43eb_b83d_0a764b472bc2"/>
+        <annotations:EMMO_6dd685dd_1895_46e4_b227_be9f7d643c25>http://dbpedia.org/page/Radiant_flux</annotations:EMMO_6dd685dd_1895_46e4_b227_be9f7d643c25>
+        <annotations:EMMO_fe015383_afb3_44a6_ae86_043628697aa2>https://doi.org/10.1351/goldbook.R05046</annotations:EMMO_fe015383_afb3_44a6_ae86_043628697aa2>
+        <rdfs:comment>The radiant energy emitted, reflected, transmitted or received, per unit time.</rdfs:comment>
+        <rdfs:label xml:lang="en">RadiantFlux</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://emmo.info/middle/units-extension.owl#EMMO_f1a51559_aa3d_43a0_9327_918039f0dfed -->
+
+    <owl:Class rdf:about="http://emmo.info/middle/units-extension.owl#EMMO_f1a51559_aa3d_43a0_9327_918039f0dfed">
+        <rdfs:subClassOf rdf:resource="http://emmo.info/emmo/middle/isq#EMMO_2946d40b_24a1_47fa_8176_e3f79bb45064"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://emmo.info/emmo/middle/metrology#EMMO_67fc0a36_8dcb_4ffa_9a43_31074efa3296"/>
+                <owl:allValuesFrom>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://emmo.info/emmo/middle/metrology#EMMO_bed1d005_b04e_4a90_94cf_02bc678a8569"/>
+                        <owl:allValuesFrom rdf:resource="http://emmc.info/middle/units-extension#EMMO_9141801c_c539_4c72_b423_8c74ff6b8f05"/>
+                    </owl:Restriction>
+                </owl:allValuesFrom>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <annotations:EMMO_6dd685dd_1895_46e4_b227_be9f7d643c25>http://dbpedia.org/page/Volume</annotations:EMMO_6dd685dd_1895_46e4_b227_be9f7d643c25>
+        <rdfs:comment>Extent of an object in space.</rdfs:comment>
+        <rdfs:label xml:lang="en">Volume</rdfs:label>
+    </owl:Class>
 </rdf:RDF>
 
 
 
-<!-- Generated by the OWL API (version 4.2.8.20170104-2310) https://github.com/owlcs/owlapi -->
+<!-- Generated by the OWL API (version 4.5.9.2019-02-01T07:24:44Z) https://github.com/owlcs/owlapi -->
 

--- a/top/annotations.owl
+++ b/top/annotations.owl
@@ -65,6 +65,16 @@ Version 1.0.0-alpha2</owl:versionInfo>
     
 
 
+    <!-- http://emmo.info/emmo/top/annotations#EMMO_50c298c2_55a2_4068_b3ac_4e948c33181f -->
+
+    <owl:AnnotationProperty rdf:about="http://emmo.info/emmo/top/annotations#EMMO_50c298c2_55a2_4068_b3ac_4e948c33181f">
+        <rdfs:comment>URL to corresponding entry in the IEC Electropedia online database of ISO 80000 terms and definitions of quantities and units available at http://www.electropedia.org/.</rdfs:comment>
+        <rdfs:label xml:lang="en">IECEntry</rdfs:label>
+        <rdfs:subPropertyOf rdf:resource="http://www.w3.org/2000/01/rdf-schema#seeAlso"/>
+    </owl:AnnotationProperty>
+    
+
+
     <!-- http://emmo.info/emmo/top/annotations#EMMO_5525a055_dda5_4556_8b91_f0d22fa676cc -->
 
     <owl:AnnotationProperty rdf:about="http://emmo.info/emmo/top/annotations#EMMO_5525a055_dda5_4556_8b91_f0d22fa676cc">


### PR DESCRIPTION
Moved DimensionOne from isq to metrology.
    
Reason: UnitOne relates to DimensionOne and is defined in metrology
