### PR TITLE
Added ISQDimensionlessQuantity and its two subclasses PureNumberQuant…

### DIFF
--- a/middle/isq.owl
+++ b/middle/isq.owl
@@ -729,6 +729,30 @@ Temperature is a relative quantity that can be used to express temperature diffe
     
 
 
+    <!-- http://emmo.info/emmo/middle/isq#EMMO_a66427d1_9932_4363_9ec5_7d91f2bfda1e -->
+
+    <owl:Class rdf:about="http://emmo.info/emmo/middle/isq#EMMO_a66427d1_9932_4363_9ec5_7d91f2bfda1e">
+        <rdfs:subClassOf rdf:resource="http://emmo.info/emmo/middle/isq#EMMO_2946d40b_24a1_47fa_8176_e3f79bb45064"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://emmo.info/emmo/middle/metrology#EMMO_67fc0a36_8dcb_4ffa_9a43_31074efa3296"/>
+                <owl:allValuesFrom>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://emmo.info/emmo/middle/metrology#EMMO_bed1d005_b04e_4a90_94cf_02bc678a8569"/>
+                        <owl:allValuesFrom rdf:resource="http://emmo.info/emmo/middle/metrology#EMMO_3227b821_26a5_4c7c_9c01_5c24483e0bd0"/>
+                    </owl:Restriction>
+                </owl:allValuesFrom>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <annotations:EMMO_6dd685dd_1895_46e4_b227_be9f7d643c25>http://dbpedia.org/page/Dimensionless_quantity</annotations:EMMO_6dd685dd_1895_46e4_b227_be9f7d643c25>
+        <annotations:EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9>A quantity to which no physical dimension is assigned and with a corresponding unit of measurement in the SI of the unit one.</annotations:EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9>
+        <annotations:EMMO_c84c6752_6d64_48cc_9500_e54a3c34898d>https://en.wikipedia.org/wiki/Dimensionless_quantity</annotations:EMMO_c84c6752_6d64_48cc_9500_e54a3c34898d>
+        <annotations:EMMO_fe015383_afb3_44a6_ae86_043628697aa2>https://doi.org/10.1351/goldbook.D01742</annotations:EMMO_fe015383_afb3_44a6_ae86_043628697aa2>
+        <rdfs:label xml:lang="en">ISQDimensionlessQuantity</rdfs:label>
+    </owl:Class>
+    
+
+
     <!-- http://emmo.info/emmo/middle/isq#EMMO_a77a0a4b_6bd2_42b2_be27_4b63cebbb59e -->
 
     <owl:Class rdf:about="http://emmo.info/emmo/middle/isq#EMMO_a77a0a4b_6bd2_42b2_be27_4b63cebbb59e">
@@ -845,6 +869,25 @@ Temperature is a relative quantity that can be used to express temperature diffe
         <annotations:EMMO_70fe84ff_99b6_4206_a9fc_9a8931836d84>The total luminous flux incident on a surface, per unit area.</annotations:EMMO_70fe84ff_99b6_4206_a9fc_9a8931836d84>
         <annotations:EMMO_fe015383_afb3_44a6_ae86_043628697aa2>https://doi.org/10.1351/goldbook.I02941</annotations:EMMO_fe015383_afb3_44a6_ae86_043628697aa2>
         <rdfs:label xml:lang="en">Illuminance</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://emmo.info/emmo/middle/isq#EMMO_ba882f34_0d71_4e4f_9d92_0c076c633a2c -->
+
+    <owl:Class rdf:about="http://emmo.info/emmo/middle/isq#EMMO_ba882f34_0d71_4e4f_9d92_0c076c633a2c">
+        <rdfs:subClassOf rdf:resource="http://emmo.info/emmo/middle/isq#EMMO_a66427d1_9932_4363_9ec5_7d91f2bfda1e"/>
+        <annotations:EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9>A pure number, typically the number of something.</annotations:EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9>
+        <annotations:EMMO_b432d2d5_25f4_4165_99c5_5935a7763c1a>1, 
+i, 
+π,
+the number of protons in the nucleus of an atom</annotations:EMMO_b432d2d5_25f4_4165_99c5_5935a7763c1a>
+        <rdfs:comment>According to the SI brochure counting does not automatically qualify a quantity as an amount of substance.
+
+This quantity is used only to describe the outcome of a counting process, without regard of the type of entities.
+
+&quot;There are also some quantities that cannot be described in terms of the seven base quantities of the SI, but have the nature of a count. Examples are a number of molecules, a number of cellular or biomolecular entities (for example copies of a particular nucleic acid sequence), or degeneracy in quantum mechanics. Counting quantities are also quantities with the associated unit one.&quot;</rdfs:comment>
+        <rdfs:label xml:lang="en">PureNumberQuantity</rdfs:label>
     </owl:Class>
     
 
@@ -1020,6 +1063,8 @@ Temperature is a relative quantity that can be used to express temperature diffe
             </owl:Restriction>
         </owl:equivalentClass>
         <rdfs:subClassOf rdf:resource="http://emmo.info/emmo/middle/metrology#EMMO_9895a1b4_f0a5_4167_ac5e_97db40b8bfcc"/>
+        <rdfs:comment>&quot;In the name “amount of substance”, the word “substance” will typically be replaced by words to specify the substance concerned in any particular application, for example “amount of hydrogen chloride, HCl”, or “amount of benzene, C6H6 ”. It is important to give a precise definition of the entity involved (as emphasized in the definition of the mole); this should preferably be done by specifying the molecular chemical formula of the material involved. Although the word “amount” has a more general dictionary definition, the abbreviation of the full name “amount of substance” to “amount” may be used for brevity.&quot;
+SI Brochure</rdfs:comment>
         <rdfs:label xml:lang="en">AmountDimension</rdfs:label>
     </owl:Class>
     
@@ -1171,6 +1216,25 @@ Temperature is a relative quantity that can be used to express temperature diffe
     
 
 
+    <!-- http://emmo.info/emmo/middle/isq#EMMO_faab3f84_e475_4a46_af9c_7d249f0b9aef -->
+
+    <owl:Class rdf:about="http://emmo.info/emmo/middle/isq#EMMO_faab3f84_e475_4a46_af9c_7d249f0b9aef">
+        <rdfs:subClassOf rdf:resource="http://emmo.info/emmo/middle/isq#EMMO_a66427d1_9932_4363_9ec5_7d91f2bfda1e"/>
+        <annotations:EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9>The ratio of two quantities of the same kind.</annotations:EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9>
+        <annotations:EMMO_b432d2d5_25f4_4165_99c5_5935a7763c1a>refractive index,
+volume fraction,
+fine structure constant</annotations:EMMO_b432d2d5_25f4_4165_99c5_5935a7763c1a>
+        <rdfs:comment>It has been argued [1] that quantities defined as ratios Q=A/B having equal dimensions in numerator and denominator are unitless quantities but still have physical dimension defined as dim(A)/dim(B).
+
+Since a quantity in EMMO gets its physical dimensionality from its unit, EMMO defines subclasses of UnitOne with units like MassPerMassUnit, as the measurement unit for rational quantities.
+
+[1] Johansson, Ingvar (2010). &quot;Metrological thinking needs the notions of parametric quantities, units and dimensions&quot;. Metrologia. 47 (3): 219–230. doi:10.1088/0026-1394/47/3/012. ISSN 0026-1394.</rdfs:comment>
+        <rdfs:label xml:lang="en">RatioQuantity</rdfs:label>
+        <rdfs:seeAlso>https://iopscience.iop.org/article/10.1088/0026-1394/47/3/012</rdfs:seeAlso>
+    </owl:Class>
+    
+
+
     <!-- http://emmo.info/emmo/middle/isq#EMMO_ffb73b1e_5786_43e4_a964_cb32ac7affb7 -->
 
     <owl:Class rdf:about="http://emmo.info/emmo/middle/isq#EMMO_ffb73b1e_5786_43e4_a964_cb32ac7affb7">
@@ -1192,63 +1256,6 @@ Temperature is a relative quantity that can be used to express temperature diffe
         <annotations:EMMO_fe015383_afb3_44a6_ae86_043628697aa2>https://doi.org/10.1351/goldbook.E01925</annotations:EMMO_fe015383_afb3_44a6_ae86_043628697aa2>
         <rdfs:comment>Inverse of &apos;ElectricalResistance&apos;.</rdfs:comment>
         <rdfs:label xml:lang="en">ElectricConductance</rdfs:label>
-    </owl:Class>
-    
-
-
-    <!-- http://emmo.info/emmo/middle/isq#EMMO_a66427d1_9932_4363_9ec5_7d91f2bfda1e -->
-
-    <owl:Class rdf:about="http://emmo.info/emmo/middle/isq#EMMO_a66427d1_9932_4363_9ec5_7d91f2bfda1e">
-        <rdfs:subClassOf rdf:resource="http://emmo.info/emmo/middle/isq#EMMO_2946d40b_24a1_47fa_8176_e3f79bb45064"/>
-        <rdfs:subClassOf>
-            <owl:Restriction>
-                <owl:onProperty rdf:resource="http://emmo.info/emmo/middle/metrology#EMMO_67fc0a36_8dcb_4ffa_9a43_31074efa3296"/>
-                <owl:allValuesFrom>
-                    <owl:Restriction>
-                        <owl:onProperty rdf:resource="http://emmo.info/emmo/middle/metrology#EMMO_bed1d005_b04e_4a90_94cf_02bc678a8569"/>
-                        <owl:allValuesFrom rdf:resource="http://emmo.info/emmo/middle/metrology#EMMO_3227b821_26a5_4c7c_9c01_5c24483e0bd0"/>
-                    </owl:Restriction>
-                </owl:allValuesFrom>
-            </owl:Restriction>
-        </rdfs:subClassOf>
-        <annotations:EMMO_6dd685dd_1895_46e4_b227_be9f7d643c25>http://dbpedia.org/page/Dimensionless_quantity</annotations:EMMO_6dd685dd_1895_46e4_b227_be9f7d643c25>
-        <annotations:EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9>A quantity to which no physical dimension is assigned and with a corresponding unit of measurement in the SI of the unit one.</annotations:EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9>
-        <annotations:EMMO_c84c6752_6d64_48cc_9500_e54a3c34898d>https://en.wikipedia.org/wiki/Dimensionless_quantity</annotations:EMMO_c84c6752_6d64_48cc_9500_e54a3c34898d>
-        <annotations:EMMO_fe015383_afb3_44a6_ae86_043628697aa2>https://doi.org/10.1351/goldbook.D01742</annotations:EMMO_fe015383_afb3_44a6_ae86_043628697aa2>
-        <rdfs:label xml:lang="en">ISQDimensionlessQuantity</rdfs:label>
-    </owl:Class>
-    
-
-
-    <!-- http://emmo.info/emmo/middle/isq#EMMO_ba882f34_0d71_4e4f_9d92_0c076c633a2c -->
-
-    <owl:Class rdf:about="http://emmo.info/emmo/middle/isq#EMMO_ba882f34_0d71_4e4f_9d92_0c076c633a2c">
-        <rdfs:subClassOf rdf:resource="http://emmo.info/emmo/middle/isq#EMMO_a66427d1_9932_4363_9ec5_7d91f2bfda1e"/>
-        <annotations:EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9>A pure number, typically the number of something.</annotations:EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9>
-        <annotations:EMMO_b432d2d5_25f4_4165_99c5_5935a7763c1a>1, 
-i, 
-π,
-the number of protons in the nucleus of an atom</annotations:EMMO_b432d2d5_25f4_4165_99c5_5935a7763c1a>
-        <rdfs:label xml:lang="en">PureNumberQuantity</rdfs:label>
-    </owl:Class>
-    
-
-
-    <!-- http://emmo.info/emmo/middle/isq#EMMO_faab3f84_e475_4a46_af9c_7d249f0b9aef -->
-
-    <owl:Class rdf:about="http://emmo.info/emmo/middle/isq#EMMO_faab3f84_e475_4a46_af9c_7d249f0b9aef">
-        <rdfs:subClassOf rdf:resource="http://emmo.info/emmo/middle/isq#EMMO_a66427d1_9932_4363_9ec5_7d91f2bfda1e"/>
-        <annotations:EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9>The ratio of two quantities of the same kind.</annotations:EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9>
-        <annotations:EMMO_b432d2d5_25f4_4165_99c5_5935a7763c1a>refractive index,
-volume fraction,
-fine structure constant</annotations:EMMO_b432d2d5_25f4_4165_99c5_5935a7763c1a>
-        <rdfs:comment>It has been argued [1] that quantities defined as ratios Q=A/B having equal dimensions in numerator and denominator are unitless quantities but still have physical dimension defined as dim(A)/dim(B).
-
-Since a quantity in EMMO gets its physical dimensionality from its unit, EMMO defines subclasses of UnitOne with units like MassPerMassUnit, as the measurement unit for rational quantities.
-
-[1] Johansson, Ingvar (2010). &quot;Metrological thinking needs the notions of parametric quantities, units and dimensions&quot;. Metrologia. 47 (3): 219–230. doi:10.1088/0026-1394/47/3/012. ISSN 0026-1394.</rdfs:comment>
-        <rdfs:label xml:lang="en">RatioQuantity</rdfs:label>
-        <rdfs:seeAlso>https://iopscience.iop.org/article/10.1088/0026-1394/47/3/012</rdfs:seeAlso>
     </owl:Class>
 </rdf:RDF>
 

--- a/middle/isq.owl
+++ b/middle/isq.owl
@@ -926,6 +926,7 @@ Temperature is a relative quantity that can be used to express temperature diffe
         <annotations:EMMO_6dd685dd_1895_46e4_b227_be9f7d643c25>http://dbpedia.org/page/Length</annotations:EMMO_6dd685dd_1895_46e4_b227_be9f7d643c25>
         <annotations:EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9>Extend of a spatial dimension.</annotations:EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9>
         <annotations:EMMO_fe015383_afb3_44a6_ae86_043628697aa2>https://doi.org/10.1351/goldbook.L03498</annotations:EMMO_fe015383_afb3_44a6_ae86_043628697aa2>
+        <rdfs:comment>Length is a non-negative additive quantity attributed to a one-dimensional object in space.</rdfs:comment>
         <rdfs:label xml:lang="en">Length</rdfs:label>
     </owl:Class>
     
@@ -1027,7 +1028,7 @@ Temperature is a relative quantity that can be used to express temperature diffe
     <!-- http://emmo.info/emmo/middle/isq#EMMO_e7c9f7fd_e534_4441_88fe_1fec6cb20f26 -->
 
     <owl:Class rdf:about="http://emmo.info/emmo/middle/isq#EMMO_e7c9f7fd_e534_4441_88fe_1fec6cb20f26">
-        <rdfs:subClassOf rdf:resource="http://emmo.info/emmo/middle/isq#EMMO_2946d40b_24a1_47fa_8176_e3f79bb45064"/>
+        <rdfs:subClassOf rdf:resource="http://emmo.info/emmo/middle/isq#EMMO_faab3f84_e475_4a46_af9c_7d249f0b9aef"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://emmo.info/emmo/middle/metrology#EMMO_67fc0a36_8dcb_4ffa_9a43_31074efa3296"/>
@@ -1134,7 +1135,7 @@ Temperature is a relative quantity that can be used to express temperature diffe
     <!-- http://emmo.info/emmo/middle/isq#EMMO_f3dd74c0_f480_49e8_9764_33b78638c235 -->
 
     <owl:Class rdf:about="http://emmo.info/emmo/middle/isq#EMMO_f3dd74c0_f480_49e8_9764_33b78638c235">
-        <rdfs:subClassOf rdf:resource="http://emmo.info/emmo/middle/isq#EMMO_2946d40b_24a1_47fa_8176_e3f79bb45064"/>
+        <rdfs:subClassOf rdf:resource="http://emmo.info/emmo/middle/isq#EMMO_faab3f84_e475_4a46_af9c_7d249f0b9aef"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://emmo.info/emmo/middle/metrology#EMMO_67fc0a36_8dcb_4ffa_9a43_31074efa3296"/>
@@ -1191,6 +1192,63 @@ Temperature is a relative quantity that can be used to express temperature diffe
         <annotations:EMMO_fe015383_afb3_44a6_ae86_043628697aa2>https://doi.org/10.1351/goldbook.E01925</annotations:EMMO_fe015383_afb3_44a6_ae86_043628697aa2>
         <rdfs:comment>Inverse of &apos;ElectricalResistance&apos;.</rdfs:comment>
         <rdfs:label xml:lang="en">ElectricConductance</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://emmo.info/emmo/middle/isq#EMMO_a66427d1_9932_4363_9ec5_7d91f2bfda1e -->
+
+    <owl:Class rdf:about="http://emmo.info/emmo/middle/isq#EMMO_a66427d1_9932_4363_9ec5_7d91f2bfda1e">
+        <rdfs:subClassOf rdf:resource="http://emmo.info/emmo/middle/isq#EMMO_2946d40b_24a1_47fa_8176_e3f79bb45064"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://emmo.info/emmo/middle/metrology#EMMO_67fc0a36_8dcb_4ffa_9a43_31074efa3296"/>
+                <owl:allValuesFrom>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://emmo.info/emmo/middle/metrology#EMMO_bed1d005_b04e_4a90_94cf_02bc678a8569"/>
+                        <owl:allValuesFrom rdf:resource="http://emmo.info/emmo/middle/metrology#EMMO_3227b821_26a5_4c7c_9c01_5c24483e0bd0"/>
+                    </owl:Restriction>
+                </owl:allValuesFrom>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <annotations:EMMO_6dd685dd_1895_46e4_b227_be9f7d643c25>http://dbpedia.org/page/Dimensionless_quantity</annotations:EMMO_6dd685dd_1895_46e4_b227_be9f7d643c25>
+        <annotations:EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9>A quantity to which no physical dimension is assigned and with a corresponding unit of measurement in the SI of the unit one.</annotations:EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9>
+        <annotations:EMMO_c84c6752_6d64_48cc_9500_e54a3c34898d>https://en.wikipedia.org/wiki/Dimensionless_quantity</annotations:EMMO_c84c6752_6d64_48cc_9500_e54a3c34898d>
+        <annotations:EMMO_fe015383_afb3_44a6_ae86_043628697aa2>https://doi.org/10.1351/goldbook.D01742</annotations:EMMO_fe015383_afb3_44a6_ae86_043628697aa2>
+        <rdfs:label xml:lang="en">ISQDimensionlessQuantity</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://emmo.info/emmo/middle/isq#EMMO_ba882f34_0d71_4e4f_9d92_0c076c633a2c -->
+
+    <owl:Class rdf:about="http://emmo.info/emmo/middle/isq#EMMO_ba882f34_0d71_4e4f_9d92_0c076c633a2c">
+        <rdfs:subClassOf rdf:resource="http://emmo.info/emmo/middle/isq#EMMO_a66427d1_9932_4363_9ec5_7d91f2bfda1e"/>
+        <annotations:EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9>A pure number, typically the number of something.</annotations:EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9>
+        <annotations:EMMO_b432d2d5_25f4_4165_99c5_5935a7763c1a>1, 
+i, 
+π,
+the number of protons in the nucleus of an atom</annotations:EMMO_b432d2d5_25f4_4165_99c5_5935a7763c1a>
+        <rdfs:label xml:lang="en">PureNumberQuantity</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://emmo.info/emmo/middle/isq#EMMO_faab3f84_e475_4a46_af9c_7d249f0b9aef -->
+
+    <owl:Class rdf:about="http://emmo.info/emmo/middle/isq#EMMO_faab3f84_e475_4a46_af9c_7d249f0b9aef">
+        <rdfs:subClassOf rdf:resource="http://emmo.info/emmo/middle/isq#EMMO_a66427d1_9932_4363_9ec5_7d91f2bfda1e"/>
+        <annotations:EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9>The ratio of two quantities of the same kind.</annotations:EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9>
+        <annotations:EMMO_b432d2d5_25f4_4165_99c5_5935a7763c1a>refractive index,
+volume fraction,
+fine structure constant</annotations:EMMO_b432d2d5_25f4_4165_99c5_5935a7763c1a>
+        <rdfs:comment>It has been argued [1] that quantities defined as ratios Q=A/B having equal dimensions in numerator and denominator are unitless quantities but still have physical dimension defined as dim(A)/dim(B).
+
+Since a quantity in EMMO gets its physical dimensionality from its unit, EMMO defines subclasses of UnitOne with units like MassPerMassUnit, as the measurement unit for rational quantities.
+
+[1] Johansson, Ingvar (2010). &quot;Metrological thinking needs the notions of parametric quantities, units and dimensions&quot;. Metrologia. 47 (3): 219–230. doi:10.1088/0026-1394/47/3/012. ISSN 0026-1394.</rdfs:comment>
+        <rdfs:label xml:lang="en">RatioQuantity</rdfs:label>
+        <rdfs:seeAlso>https://iopscience.iop.org/article/10.1088/0026-1394/47/3/012</rdfs:seeAlso>
     </owl:Class>
 </rdf:RDF>
 

--- a/middle/metrology.owl
+++ b/middle/metrology.owl
@@ -101,21 +101,6 @@ It provides the connection between the physical world, materials characterisatio
     
 
 
-    <!-- http://emmo.info/emmo/middle/metrology#EMMO_3227b821_26a5_4c7c_9c01_5c24483e0bd0 -->
-
-    <owl:Class rdf:about="http://emmo.info/emmo/middle/metrology#EMMO_3227b821_26a5_4c7c_9c01_5c24483e0bd0">
-        <owl:equivalentClass>
-            <owl:Restriction>
-                <owl:onProperty rdf:resource="http://emmo.info/emmo/middle/perceptual#EMMO_23b579e1_8088_45b5_9975_064014026c42"/>
-                <owl:hasValue>T0 L0 M0 I0 Θ0 N0 J0</owl:hasValue>
-            </owl:Restriction>
-        </owl:equivalentClass>
-        <rdfs:subClassOf rdf:resource="http://emmo.info/emmo/middle/metrology#EMMO_9895a1b4_f0a5_4167_ac5e_97db40b8bfcc"/>
-        <rdfs:label xml:lang="en">DimensionOne</rdfs:label>
-    </owl:Class>
-    
-
-
     <!-- http://emmo.info/emmo/middle/metrology#EMMO_02c0621e_a527_4790_8a0f_2bb51973c819 -->
 
     <owl:Class rdf:about="http://emmo.info/emmo/middle/metrology#EMMO_02c0621e_a527_4790_8a0f_2bb51973c819">
@@ -247,6 +232,23 @@ This is peculiar to EMMO, where quantities (symbolic) are distinct with properti
         <rdfs:subClassOf rdf:resource="http://emmo.info/emmo/middle/metrology#EMMO_e13b2173_1dec_4b97_9ac1_1dc4b418612a"/>
         <annotations:EMMO_21ae69b4_235e_479d_8dd8_4f756f694c1b>µ</annotations:EMMO_21ae69b4_235e_479d_8dd8_4f756f694c1b>
         <rdfs:label xml:lang="en">MicroUnit</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://emmo.info/emmo/middle/metrology#EMMO_3227b821_26a5_4c7c_9c01_5c24483e0bd0 -->
+
+    <owl:Class rdf:about="http://emmo.info/emmo/middle/metrology#EMMO_3227b821_26a5_4c7c_9c01_5c24483e0bd0">
+        <owl:equivalentClass>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://emmo.info/emmo/middle/perceptual#EMMO_23b579e1_8088_45b5_9975_064014026c42"/>
+                <owl:hasValue>T0 L0 M0 I0 Θ0 N0 J0</owl:hasValue>
+            </owl:Restriction>
+        </owl:equivalentClass>
+        <rdfs:subClassOf rdf:resource="http://emmo.info/emmo/middle/metrology#EMMO_9895a1b4_f0a5_4167_ac5e_97db40b8bfcc"/>
+        <rdfs:comment>&quot;The unit one is the neutral element of any system of units – necessary and present automatically.&quot;
+SI Brochure</rdfs:comment>
+        <rdfs:label xml:lang="en">DimensionOne</rdfs:label>
     </owl:Class>
     
 
@@ -647,6 +649,14 @@ International vocabulary of metrology (VIM)</rdfs:comment>
     
 
 
+    <!-- http://emmo.info/emmo/middle/metrology#EMMO_dd4a7f3e_ef56_466c_ac1a_d2716b5f87ec -->
+
+    <owl:Class rdf:about="http://emmo.info/emmo/middle/metrology#EMMO_dd4a7f3e_ef56_466c_ac1a_d2716b5f87ec">
+        <rdfs:subClassOf rdf:resource="http://emmo.info/emmo/middle/metrology#EMMO_f658c301_ce93_46cf_9639_4eace2c5d1d5"/>
+    </owl:Class>
+    
+
+
     <!-- http://emmo.info/emmo/middle/metrology#EMMO_e13b2173_1dec_4b97_9ac1_1dc4b418612a -->
 
     <owl:Class rdf:about="http://emmo.info/emmo/middle/metrology#EMMO_e13b2173_1dec_4b97_9ac1_1dc4b418612a">
@@ -713,14 +723,6 @@ So, for the EMMO the symbol &quot;kg&quot; is not a physical quantity but simply
 
 While the string &quot;1 kg&quot; is a &apos;Physical Quantity&apos;.</rdfs:comment>
         <rdfs:label xml:lang="en">Quantity</rdfs:label>
-    </owl:Class>
-    
-
-
-    <!-- http://emmo.info/emmo/middle/metrology#EMMO_dd4a7f3e_ef56_466c_ac1a_d2716b5f87ec -->
-
-    <owl:Class rdf:about="http://emmo.info/emmo/middle/metrology#EMMO_dd4a7f3e_ef56_466c_ac1a_d2716b5f87ec">
-        <rdfs:subClassOf rdf:resource="http://emmo.info/emmo/middle/metrology#EMMO_f658c301_ce93_46cf_9639_4eace2c5d1d5"/>
     </owl:Class>
 </rdf:RDF>
 


### PR DESCRIPTION
    Added ISQDimensionlessQuantity and its two subclasses PureNumberQuantity and RatioQuantity.
    
    Even though all dimensionless quantities are not of the same kind, it is
    useful to categorise them as dimensionless quantities, especially because
    the physical dimensionality of ratio quantities are specialised subclasses
    of dimension one while the physical dimension of pure number quantities
    is just dimension one.
