### PR TITLE
Updated literals ending with a double quote.

### DIFF
--- a/middle/isq.ttl
+++ b/middle/isq.ttl
@@ -1184,7 +1184,7 @@ the number of protons in the nucleus of an atom""" ;
 
 This quantity is used only to describe the outcome of a counting process, without regard of the type of entities.
 
-\"There are also some quantities that cannot be described in terms of the seven base quantities of the SI, but have the nature of a count. Examples are a number of molecules, a number of cellular or biomolecular entities (for example copies of a particular nucleic acid sequence), or degeneracy in quantum mechanics. Counting quantities are also quantities with the associated unit one.\""""@en ;
+There are also some quantities that cannot be described in terms of the seven base quantities of the SI, but have the nature of a count. Examples are a number of molecules, a number of cellular or biomolecular entities (for example copies of a particular nucleic acid sequence), or degeneracy in quantum mechanics. Counting quantities are also quantities with the associated unit one."""@en ;
                                            skos:prefLabel "PureNumberQuantity"@en .
 
 

--- a/middle/manufacturing.ttl
+++ b/middle/manufacturing.ttl
@@ -58,7 +58,7 @@ email: emanuele.ghedini@unibo.it"""@en ,
                                            :EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9 "An engineered object which is instrumental for reaching a particular purpose through its characteristic functioning process, with particular reference to mechanical or electronic equipment."@en ;
                                            rdfs:comment """From Old French \"deviser\", meaning: arrange, plan, contrive.
 
-Literally \"dispose in portions,\" from Vulgar Latin \"divisare\", frequentative of Latin dividere, meaning \"to divide\""""@en ;
+Literally \"dispose in portions,\" from Vulgar Latin \"divisare\", frequentative of Latin dividere, meaning \"to divide\"."""@en ;
                                            skos:prefLabel "Device"@en .
 
 


### PR DESCRIPTION
At least owlapi escapes the end quote, but not the start quote, in
literals ending with a double quote when serialising to turtle. That
makes the quotes in the literal not matching, confusing editors and
other tools.  The solution is to end literals with something else than
a double quote or escape them explicitely.