### PR TITLE
Updated mereotopological relations:

### DIFF
--- a/middle/ordinal.ttl
+++ b/middle/ordinal.ttl
@@ -11,15 +11,15 @@
 <http://emmo.info/emmo/middle/ordinal> rdf:type owl:Ontology ;
                                         owl:versionIRI <http://emmo.info/emmo/1.0.0-beta/middle/ordinal> ;
                                         owl:imports <http://emmo.info/emmo/1.0.0-beta/middle/reductionistic> ;
-                                       dcterms:abstract "The ordinal module defines ordering based on direct parthood. It allows EMMO to describe arrays and data structures in programming languages enabling low-level semantic interoperability."@en ;
-                                       dcterms:contributor "University of Bologna, IT" ,
-                                                           "SINTEF, NO" ;
-                                       dcterms:creator "Emanuele Ghedini" ,
-                                                       "Jesper Friis" ;
-                                       dcterms:license "https://creativecommons.org/licenses/by/4.0/legalcode" ;
-                                       dcterms:publisher "EMMC ASBL" ;
-                                       dcterms:title "Ordinal"@en ;
-                                       rdfs:comment """Contacts:
+                                        dcterms:abstract "The ordinal module defines ordering based on direct parthood. It allows EMMO to describe arrays and data structures in programming languages enabling low-level semantic interoperability."@en ;
+                                        dcterms:contributor "SINTEF, NO" ,
+                                                            "University of Bologna, IT" ;
+                                        dcterms:creator "Emanuele Ghedini" ,
+                                                        "Jesper Friis" ;
+                                        dcterms:license "https://creativecommons.org/licenses/by/4.0/legalcode" ;
+                                        dcterms:publisher "EMMC ASBL" ;
+                                        dcterms:title "Ordinal"@en ;
+                                        rdfs:comment """Contacts:
 Gerhard Goldbeck
 Goldbeck Consulting Ltd (UK)
 email: gerhard@goldbeck-consulting.com
@@ -27,8 +27,8 @@ email: gerhard@goldbeck-consulting.com
 Emanuele Ghedini
 University of Bologna (IT)
 email: emanuele.ghedini@unibo.it"""@en ,
-                                                    "The EMMO requires FacT++ reasoner plugin in order to visualize all inferences and class hierarchy (ctrl+R hotkey in Protege)."@en ;
-                                       owl:versionInfo "1.0.0-beta" .
+                                                     "The EMMO requires FacT++ reasoner plugin in order to visualize all inferences and class hierarchy (ctrl+R hotkey in Protege)."@en ;
+                                        owl:versionInfo "1.0.0-beta" .
 
 #################################################################
 #    Object Properties
@@ -42,6 +42,7 @@ email: emanuele.ghedini@unibo.it"""@en ,
                                                     owl:IrreflexiveProperty ;
                                            rdfs:domain :EMMO_25a3da5e_eab1_42dd_8081_61dd09d34e1b ;
                                            rdfs:range :EMMO_42fc460a_4bf3_4d0b_8dee_3c7efcefebb5 ;
+                                           :EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9 "hasSpatialLast refer to the last element in an ordered arrangement."@en ;
                                            skos:prefLabel "hasSpatialLast"@en .
 
 
@@ -53,54 +54,61 @@ email: emanuele.ghedini@unibo.it"""@en ,
                                                     owl:IrreflexiveProperty ;
                                            rdfs:domain :EMMO_25a3da5e_eab1_42dd_8081_61dd09d34e1b ;
                                            rdfs:range :EMMO_42fc460a_4bf3_4d0b_8dee_3c7efcefebb5 ;
+                                           :EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9 """hasSpatialFirst refer to the first element in an ordered arrangement.
+
+hasSpatialFirst can either be used together with hasSpatialNext to declare spatially ordered linear lists or together with hasSpatialRest to declare general (possible branched) arrangements."""@en ;
                                            skos:prefLabel "hasSpatialFirst"@en .
 
 
 ###  http://emmo.info/emmo#EMMO_499e24a5_5072_4c83_8625_fe3f96ae4a8d
 :EMMO_499e24a5_5072_4c83_8625_fe3f96ae4a8d rdf:type owl:ObjectProperty ;
                                            rdfs:subPropertyOf :EMMO_52d08d7d_e9e4_43e5_8508_d353e7e3a23a ;
-                                           rdf:type owl:AsymmetricProperty ,
+                                           rdf:type owl:FunctionalProperty ,
+                                                    owl:AsymmetricProperty ,
                                                     owl:IrreflexiveProperty ;
                                            rdfs:domain :EMMO_e0954911_fc88_492a_9830_fdb238e28cc2 ;
                                            rdfs:range :EMMO_e0954911_fc88_492a_9830_fdb238e28cc2 ;
+                                           :EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9 "Relates a temporal ordered element to its following element."@en ;
                                            skos:prefLabel "hasTemporalNext"@en .
 
 
 ###  http://emmo.info/emmo#EMMO_52d08d7d_e9e4_43e5_8508_d353e7e3a23a
 :EMMO_52d08d7d_e9e4_43e5_8508_d353e7e3a23a rdf:type owl:ObjectProperty ;
                                            rdfs:subPropertyOf :EMMO_4d6504f1_c470_4ce9_b941_bbbebc9ab05d ;
-                                           rdf:type owl:AsymmetricProperty ,
+                                           rdf:type owl:FunctionalProperty ,
+                                                    owl:AsymmetricProperty ,
                                                     owl:IrreflexiveProperty ;
                                            rdfs:domain :EMMO_2e9ace8a_1155_45b5_a066_d5fd9774e76c ;
                                            rdfs:range :EMMO_2e9ace8a_1155_45b5_a066_d5fd9774e76c ;
+                                           :EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9 "Relates an ordered element to the following element."@en ;
                                            skos:prefLabel "hasNext"@en .
-
-
-###  http://emmo.info/emmo#EMMO_651013cf_00ee_4e66_9d4e_fdfb20d991d2
-:EMMO_651013cf_00ee_4e66_9d4e_fdfb20d991d2 rdf:type owl:ObjectProperty ;
-                                           rdfs:subPropertyOf :EMMO_4d6504f1_c470_4ce9_b941_bbbebc9ab05d ;
-                                           rdf:type owl:AsymmetricProperty ,
-                                                    owl:IrreflexiveProperty ;
-                                           skos:prefLabel "hasRest"@en .
 
 
 ###  http://emmo.info/emmo#EMMO_66873eb5_7e42_4566_a906_bd97a832f19b
 :EMMO_66873eb5_7e42_4566_a906_bd97a832f19b rdf:type owl:ObjectProperty ;
-                                           rdfs:subPropertyOf :EMMO_651013cf_00ee_4e66_9d4e_fdfb20d991d2 ;
-                                           rdf:type owl:AsymmetricProperty ,
+                                           rdfs:subPropertyOf :EMMO_b2282816_b7a3_44c6_b2cb_3feff1ceb7fe ;
+                                           rdf:type owl:FunctionalProperty ,
+                                                    owl:AsymmetricProperty ,
                                                     owl:IrreflexiveProperty ;
-                                           rdfs:domain :EMMO_42fc460a_4bf3_4d0b_8dee_3c7efcefebb5 ;
+                                           rdfs:domain :EMMO_25a3da5e_eab1_42dd_8081_61dd09d34e1b ;
                                            rdfs:range :EMMO_25a3da5e_eab1_42dd_8081_61dd09d34e1b ;
+                                           :EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9 """Is used to declare general (possible non-linear) arrangements.
+
+An arrangement who's structure is described with hasSpatialFirst/hasSpatialRest has one hasSpatialFirst relation that refer to its first element and one hasSpatialRest relation that refer to an another (sub-)arrangement with all the remaining elements."""@en ;
+                                           rdfs:comment ""@en ,
+                                                        "Corresponds to rdf:rest, except that it connects two arrangements."@en ;
                                            skos:prefLabel "hasSpatialRest"@en .
 
 
 ###  http://emmo.info/emmo#EMMO_8785be5a_2493_4b12_8f39_31907ab11748
 :EMMO_8785be5a_2493_4b12_8f39_31907ab11748 rdf:type owl:ObjectProperty ;
                                            rdfs:subPropertyOf :EMMO_52d08d7d_e9e4_43e5_8508_d353e7e3a23a ;
-                                           rdf:type owl:AsymmetricProperty ,
+                                           rdf:type owl:FunctionalProperty ,
+                                                    owl:AsymmetricProperty ,
                                                     owl:IrreflexiveProperty ;
                                            rdfs:domain :EMMO_42fc460a_4bf3_4d0b_8dee_3c7efcefebb5 ;
                                            rdfs:range :EMMO_42fc460a_4bf3_4d0b_8dee_3c7efcefebb5 ;
+                                           :EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9 "Relates a spatial ordered element to its following element."@en ;
                                            skos:prefLabel "hasSpatialNext"@en .
 
 
@@ -112,16 +120,19 @@ email: emanuele.ghedini@unibo.it"""@en ,
                                                     owl:IrreflexiveProperty ;
                                            rdfs:domain :EMMO_406f9b74_c927_4e05_b9af_5edbe5e280c5 ;
                                            rdfs:range :EMMO_e0954911_fc88_492a_9830_fdb238e28cc2 ;
+                                           :EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9 "hasTemporalLast refer to the last element in an ordered sequence."@en ;
                                            skos:prefLabel "hasTemporalLast"@en .
 
 
 ###  http://emmo.info/emmo#EMMO_fb168b10_a27b_4409_a002_35671319d170
 :EMMO_fb168b10_a27b_4409_a002_35671319d170 rdf:type owl:ObjectProperty ;
-                                           rdfs:subPropertyOf :EMMO_651013cf_00ee_4e66_9d4e_fdfb20d991d2 ;
-                                           rdf:type owl:AsymmetricProperty ,
+                                           rdfs:subPropertyOf :EMMO_65a2c5b8_e4d8_4a51_b2f8_e55effc0547d ;
+                                           rdf:type owl:FunctionalProperty ,
+                                                    owl:AsymmetricProperty ,
                                                     owl:IrreflexiveProperty ;
-                                           rdfs:domain :EMMO_e0954911_fc88_492a_9830_fdb238e28cc2 ;
+                                           rdfs:domain :EMMO_406f9b74_c927_4e05_b9af_5edbe5e280c5 ;
                                            rdfs:range :EMMO_406f9b74_c927_4e05_b9af_5edbe5e280c5 ;
+                                           rdfs:comment "Corresponds to rdf:rest, except that it connects two sequences."@en ;
                                            skos:prefLabel "hasTemporalRest"@en .
 
 
@@ -133,6 +144,9 @@ email: emanuele.ghedini@unibo.it"""@en ,
                                                     owl:IrreflexiveProperty ;
                                            rdfs:domain :EMMO_406f9b74_c927_4e05_b9af_5edbe5e280c5 ;
                                            rdfs:range :EMMO_e0954911_fc88_492a_9830_fdb238e28cc2 ;
+                                           :EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9 """hasTemporalFirst refer to the first element in an ordered sequence.
+
+hasTemporalFirst can either be used together with hasTemporalNext to declare temporal ordered linear sequences or together with hasTemporalRest to declare general (possible branched) temporal sequences."""@en ;
                                            skos:prefLabel "hasTemporalFirst"@en .
 
 

--- a/middle/reductionistic.ttl
+++ b/middle/reductionistic.ttl
@@ -50,6 +50,7 @@ email: emanuele.ghedini@unibo.it"""@en ,
                                                     owl:IrreflexiveProperty ;
                                            rdfs:domain :EMMO_52211e5e_d767_4812_845e_eb6b402c476a ;
                                            rdfs:range :EMMO_36c79456_e29c_400d_8bd3_0eedddb82652 ;
+                                           :EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9 "hasTemporalDirectPart refer to an object in the very next lower level of temporal granularity that shares the same spatial extend as the original object."@en ;
                                            skos:prefLabel "hasTemporalDirectPart"@en .
 
 
@@ -59,6 +60,7 @@ email: emanuele.ghedini@unibo.it"""@en ,
                                            rdf:type owl:InverseFunctionalProperty ,
                                                     owl:AsymmetricProperty ,
                                                     owl:IrreflexiveProperty ;
+                                           :EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9 "hasSpatioTemporalDirectPart refer to an object in the very next lower level of spatial granularity in both space and time."@en ;
                                            skos:prefLabel "hasSpatioTemporalDirectPart"@en .
 
 
@@ -69,6 +71,11 @@ email: emanuele.ghedini@unibo.it"""@en ,
                                                     owl:AsymmetricProperty ,
                                                     owl:IrreflexiveProperty ;
                                            rdfs:domain :EMMO_36c79456_e29c_400d_8bd3_0eedddb82652 ;
+                                           :EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9 "hasSpatialDirectPart refer to an object in the very next lower level of spatial granularity that shares the same temporal extend as the original object."@en ;
+                                           rdfs:comment "Direct parthood is the key relation underlying the reductionistic perspective. It is a non-transitive proper part, that specifies elements in the very next lower level of granularity. This allows to build strict granularity hirarchies."@en ,
+                                                        """Note that EMMO does not provide a hasDirectPart relation.
+The reason for this is that direct parthood can either be decomposed into space or time independently of each other. Adding a common superclass for hasSpatialDirectPart and hasTemporalDirectPart would exclude the subclass SpatioTemporalDirectPart."""@en ,
+                                                        "hasSpatialDirectPart is non-transitive, irreflexive, asymmetric and inverse functional."@en ;
                                            skos:prefLabel "hasSpatialDirectPart"@en .
 
 

--- a/top/mereotopology.ttl
+++ b/top/mereotopology.ttl
@@ -55,6 +55,10 @@ email: emanuele.ghedini@unibo.it"""@en ,
                                            rdfs:subPropertyOf :EMMO_8c898653_1118_4682_9bbf_6cc334d16a99 ,
                                                               :EMMO_d893d373_b579_4867_841e_1c2b31a8d2c6 ;
                                            rdf:type owl:TransitiveProperty ;
+                                           :EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9 "If an object A is enclosed by another object B"@en ;
+                                           rdfs:comment """hasPart is transitive, asymmetric and reflexive.
+
+Asymmetric and reflexive are not axiomatised since they would slow down the reasoner."""@en ;
                                            skos:prefLabel "hasPart"@en .
 
 
@@ -62,13 +66,17 @@ email: emanuele.ghedini@unibo.it"""@en ,
 :EMMO_4d6504f1_c470_4ce9_b941_bbbebc9ab05d rdf:type owl:ObjectProperty ;
                                            rdfs:subPropertyOf :EMMO_6703954e_34c4_4a15_a9e7_f313760ae1a8 ;
                                            rdf:type owl:SymmetricProperty ;
+                                           :EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9 "Two objects are in contact if they share a lower dimensionality part (like a corner, edge or face) without actualy overlap."@en ;
                                            skos:prefLabel "hasContactWith"@en .
 
 
 ###  http://emmo.info/emmo#EMMO_517dfaf9_4970_41ac_81ee_d031627d2c7c
 :EMMO_517dfaf9_4970_41ac_81ee_d031627d2c7c rdf:type owl:ObjectProperty ;
                                            rdfs:subPropertyOf :EMMO_03212fd7_abfd_4828_9c8e_62c293052d4b ;
-                                           rdf:type owl:SymmetricProperty ;
+                                           rdf:type owl:SymmetricProperty ,
+                                                    owl:IrreflexiveProperty ;
+                                           :EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9 "Two objects are disconnected if they do not share any common portion of spacetime."@en ;
+                                           rdfs:comment "Disconnected is a topological relation."@en ;
                                            skos:prefLabel "disconnected"@en .
 
 
@@ -76,8 +84,11 @@ email: emanuele.ghedini@unibo.it"""@en ,
 :EMMO_6703954e_34c4_4a15_a9e7_f313760ae1a8 rdf:type owl:ObjectProperty ;
                                            rdfs:subPropertyOf :EMMO_03212fd7_abfd_4828_9c8e_62c293052d4b ;
                                            rdf:type owl:SymmetricProperty ;
-                                           rdfs:comment "Causality is a topological property between connected items."@en ,
-                                                        "Items being connected means that there is a topological contact or \"interaction\" between them."@en ;
+                                           :EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9 "Causality is a topological property between connected items."@en ;
+                                           rdfs:comment "Items being connected means that there is a topological contact or \"interaction\" between them."@en ,
+                                                        """connected is symmetric and reflexive.
+
+Reflexive is not axiomatised since that would slow down the reasoner."""@en ;
                                            skos:prefLabel "connected"@en .
 
 
@@ -95,7 +106,13 @@ email: emanuele.ghedini@unibo.it"""@en ,
 :EMMO_8c898653_1118_4682_9bbf_6cc334d16a99 rdf:type owl:ObjectProperty ;
                                            rdfs:subPropertyOf :EMMO_6703954e_34c4_4a15_a9e7_f313760ae1a8 ;
                                            rdf:type owl:TransitiveProperty ;
-                                           rdfs:comment "Enclosure is reflexive and transitive."@en ;
+                                           :EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9 """Encloses is a topological relation. The statement \"x encloses y\" means that the spacetime occupied by y is fully embedded in x. 
+
+In FOL, \"x encloses y\" it may be written 'Exy'."""@en ;
+                                           rdfs:comment """Enclosure is reflexive and transitive.
+
+Reflexive is not axiomatised since it would slow down the reasoner."""@en ,
+                                                        "Note that x and y may be the same object (hence reflectivity)."@en ;
                                            skos:prefLabel "encloses"@en .
 
 
@@ -103,6 +120,10 @@ email: emanuele.ghedini@unibo.it"""@en ,
 :EMMO_9380ab64_0363_4804_b13f_3a8a94119a76 rdf:type owl:ObjectProperty ;
                                            rdfs:subPropertyOf :EMMO_17e27c22_37e1_468c_9dd7_95e137f73e7f ;
                                            rdf:type owl:TransitiveProperty ;
+                                           rdfs:comment "The statement \"x hasProperPart y\" means that y is a part of x, excluding the case that x and y are the same object (hence irrevlexivity)."@en ,
+                                                        """hasProperPart is transitive, asymmetric and irreflexive.
+
+Asymmetric and irreflexive are not axiomatised since they would slow down the reasoner."""@en ;
                                            skos:prefLabel "hasProperPart"@en .
 
 
@@ -110,6 +131,8 @@ email: emanuele.ghedini@unibo.it"""@en ,
 :EMMO_9cb984ca_48ad_4864_b09e_50d3fff19420 rdf:type owl:ObjectProperty ;
                                            rdfs:subPropertyOf :EMMO_d893d373_b579_4867_841e_1c2b31a8d2c6 ;
                                            rdf:type owl:SymmetricProperty ;
+                                           :EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9 "The statement \"x overcrosses y\" means that x and y are overlapping, but also that neither is enclosed by the other."@en ;
+                                           rdfs:comment "overcrosses is a topological relation."@en ;
                                            skos:prefLabel "overcrosses"@en .
 
 
@@ -117,6 +140,8 @@ email: emanuele.ghedini@unibo.it"""@en ,
 :EMMO_d893d373_b579_4867_841e_1c2b31a8d2c6 rdf:type owl:ObjectProperty ;
                                            rdfs:subPropertyOf :EMMO_6703954e_34c4_4a15_a9e7_f313760ae1a8 ;
                                            rdf:type owl:SymmetricProperty ;
+                                           :EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9 "Overlap is a topological relation."@en ,
+                                                                                      "Two objects overlap if they share a common portion of spacetime."@en ;
                                            skos:prefLabel "hasOverlapWith"@en .
 
 


### PR DESCRIPTION
* annotated most of the mereotopological relations
* made disconnected irreflexive
* changed hasSpatialDirectPart from functional to inverse functional
* changed hasTemporalDirectPart from functional to inverse functional
* changed hasSpatioTemporalDirectPart from functional to inverse functional
* made hasSpatialRest a subproperty of hasSpatialDirectPart
* made hasTemporalRest a subproperty of hasTemporalDirectPart
* removed hasRest
* made all the hasNext and hasRest relations to functional

Unresolved Issue: in arrangements and sequences is the reasoner able to identify all elements, but the last, as elements. This asymmetry can be solved in two different ways:

1. introduce hasSpatialPrevious/hasTemporalPrevious defined as the inverse of hasSpatialNext/hasTemporalNext
2. introduce SpatialNil and TemporalNil

The second solution follows the RDF and LISP standards, but the physical interpretation is not straight forward.