### PR TITLE
fix qudtReferences

### DIFF
--- a/domain/isq.ttl
+++ b/domain/isq.ttl
@@ -405,6 +405,7 @@ Entropy"""@en ;
                                                              owl:onProperty :EMMO_bed1d005_b04e_4a90_94cf_02bc678a8569 ;
                                                              owl:someValuesFrom :EMMO_608a1b30_df6f_4bbb_9dc3_5c0de92fd9cf
                                                            ] ;
+                                           :EMMO_1f1b164d_ec6a_4faa_8d5e_88bda62316cc "http://qudt.org/vocab/quantitykind/Curvature" ;
                                            rdfs:comment "In geometrical optics, vergence describes the curvature of optical wavefronts."@en ;
                                            skos:prefLabel "Vergence"@en .
 
@@ -617,6 +618,7 @@ Entropy"""@en ;
                                                              owl:onProperty :EMMO_bed1d005_b04e_4a90_94cf_02bc678a8569 ;
                                                              owl:someValuesFrom :EMMO_b3600e73_3e05_479d_9714_c041c3acf5cc
                                                            ] ;
+                                           :EMMO_1f1b164d_ec6a_4faa_8d5e_88bda62316cc "http://qudt.org/vocab/quantitykind/PositionVector" ;
                                            :EMMO_70fe84ff_99b6_4206_a9fc_9a8931836d84 "Vector r characterizing a point P in a point space with a given origin point O."@en ;
                                            rdfs:comment """In the usual geometrical three-dimensional space, position vectors are quantities of the dimension length.
 
@@ -666,6 +668,7 @@ Entropy"""@en ;
                                                              owl:onProperty :EMMO_bed1d005_b04e_4a90_94cf_02bc678a8569 ;
                                                              owl:someValuesFrom :EMMO_2e7e5796_4a80_4d73_bb84_f31138446c0c
                                                            ] ;
+                                           :EMMO_1f1b164d_ec6a_4faa_8d5e_88bda62316cc "http://qudt.org/vocab/quantitykind/ElectricPotential" ;
                                            :EMMO_8de5d5bf_db1c_40ac_b698_095ba3b18578 "6-11.1" ;
                                            :EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9 "Energy required to move a unit charge through an electric field from a reference point."@en ;
                                            :EMMO_fe015383_afb3_44a6_ae86_043628697aa2 "https://doi.org/10.1351/goldbook.E01935" ;
@@ -736,7 +739,7 @@ field quantity can be added to it without changing its gradient.""" ;
                                                              owl:onProperty :EMMO_bed1d005_b04e_4a90_94cf_02bc678a8569 ;
                                                              owl:someValuesFrom :EMMO_14ff4393_0f28_4fb4_abc7_c2cc00bc761d
                                                            ] ;
-                                           :EMMO_1f1b164d_ec6a_4faa_8d5e_88bda62316cc "http://qudt.org/vocab/quantitykind/Length" ;
+                                           :EMMO_1f1b164d_ec6a_4faa_8d5e_88bda62316cc "http://qudt.org/vocab/quantitykind/LuminousIntensity" ;
                                            :EMMO_8de5d5bf_db1c_40ac_b698_095ba3b18578 "7-14" ;
                                            :EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9 "A measure of the wavelength-weighted power emitted by a light source in a particular direction per unit solid angle. It is based on the luminosity function, which is a standardized model of the sensitivity of the human eye."@en ;
                                            skos:prefLabel "LuminousIntensity"@en .
@@ -876,6 +879,7 @@ ChemicalPotential"""@en ;
                                                              owl:onProperty :EMMO_bed1d005_b04e_4a90_94cf_02bc678a8569 ;
                                                              owl:someValuesFrom :EMMO_a77a0a4b_6bd2_42b2_be27_4b63cebbb59e
                                                            ] ;
+                                           :EMMO_1f1b164d_ec6a_4faa_8d5e_88bda62316cc "http://qudt.org/vocab/quantitykind/CelciusTemperature" ;
                                            :EMMO_8de5d5bf_db1c_40ac_b698_095ba3b18578 "5-2" ;
                                            :EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9 """An objective comparative measure of hot or cold.
 
@@ -1298,6 +1302,7 @@ where g is the appropriate g factor, μ is mostly the Bohr magneton or nuclear m
                                                              owl:onProperty :EMMO_bed1d005_b04e_4a90_94cf_02bc678a8569 ;
                                                              owl:someValuesFrom :EMMO_3227b821_26a5_4c7c_9c01_5c24483e0bd0
                                                            ] ;
+                                           :EMMO_1f1b164d_ec6a_4faa_8d5e_88bda62316cc "http://qudt.org/vocab/quantitykind/Dimensionless" ;
                                            :EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9 "A quantity to which no physical dimension is assigned and with a corresponding unit of measurement in the SI of the unit one."@en ;
                                            :EMMO_c84c6752_6d64_48cc_9500_e54a3c34898d "https://en.wikipedia.org/wiki/Dimensionless_quantity" ;
                                            :EMMO_fe015383_afb3_44a6_ae86_043628697aa2 "https://doi.org/10.1351/goldbook.D01742" ;
@@ -1407,6 +1412,7 @@ where g is the appropriate g factor, μ is mostly the Bohr magneton or nuclear m
                                                              owl:onProperty :EMMO_bed1d005_b04e_4a90_94cf_02bc678a8569 ;
                                                              owl:someValuesFrom :EMMO_90798691_3b86_4d8c_910f_be2b39c98b39
                                                            ] ;
+                                           :EMMO_1f1b164d_ec6a_4faa_8d5e_88bda62316cc "http://qudt.org/vocab/quantitykind/SurfaceDensity" ;
                                            :EMMO_fe015383_afb3_44a6_ae86_043628697aa2 "https://doi.org/10.1351/goldbook.S06167" ;
                                            rdfs:comment "Mass per unit area."@en ;
                                            skos:prefLabel "AreaDensity"@en .
@@ -1420,7 +1426,7 @@ where g is the appropriate g factor, μ is mostly the Bohr magneton or nuclear m
                                                              owl:onProperty :EMMO_bed1d005_b04e_4a90_94cf_02bc678a8569 ;
                                                              owl:someValuesFrom :EMMO_a77a0a4b_6bd2_42b2_be27_4b63cebbb59e
                                                            ] ;
-                                           :EMMO_1f1b164d_ec6a_4faa_8d5e_88bda62316cc "qudt.org/vocab/quantitykind/ThermodynamicTemperature" ;
+                                           :EMMO_1f1b164d_ec6a_4faa_8d5e_88bda62316cc "http://qudt.org/vocab/quantitykind/ThermodynamicTemperature" ;
                                            :EMMO_8de5d5bf_db1c_40ac_b698_095ba3b18578 "5-1" ;
                                            :EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9 "Thermodynamic temperature is the absolute measure of temperature. It is defined by the third law of thermodynamics in which the theoretically lowest temperature is the null or zero point."@en ;
                                            :EMMO_fe015383_afb3_44a6_ae86_043628697aa2 "https://doi.org/10.1351/goldbook.T06321" ;
@@ -1584,6 +1590,7 @@ There are also some quantities that cannot be described in terms of the seven ba
                                                              owl:onProperty :EMMO_bed1d005_b04e_4a90_94cf_02bc678a8569 ;
                                                              owl:someValuesFrom :EMMO_b3600e73_3e05_479d_9714_c041c3acf5cc
                                                            ] ;
+                                           :EMMO_1f1b164d_ec6a_4faa_8d5e_88bda62316cc "http://qudt.org/vocab/quantitykind/Length" ;
                                            :EMMO_8de5d5bf_db1c_40ac_b698_095ba3b18578 "3-1.1" ;
                                            :EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9 "Extend of a spatial dimension."@en ;
                                            :EMMO_fe015383_afb3_44a6_ae86_043628697aa2 "https://doi.org/10.1351/goldbook.L03498" ;
@@ -1640,7 +1647,7 @@ Conductivity is equeal to the resiprocal of resistivity."""@en ;
                                                              owl:onProperty :EMMO_bed1d005_b04e_4a90_94cf_02bc678a8569 ;
                                                              owl:someValuesFrom :EMMO_02e894c3_b793_4197_b120_3442e08f58d1
                                                            ] ;
-                                           :EMMO_1f1b164d_ec6a_4faa_8d5e_88bda62316cc "qudt.org/vocab/quantitykind/Time" ;
+                                           :EMMO_1f1b164d_ec6a_4faa_8d5e_88bda62316cc "http://qudt.org/vocab/quantitykind/Time" ;
                                            :EMMO_70fe84ff_99b6_4206_a9fc_9a8931836d84 "One-dimensional subspace of space-time, which is locally orthogonal to space."@en ;
                                            :EMMO_8de5d5bf_db1c_40ac_b698_095ba3b18578 "3-7" ;
                                            :EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9 "The indefinite continued progress of existence and events that occur in apparently irreversible succession from the past through the present to the future."@en ;
@@ -2003,6 +2010,7 @@ It defines the base unit second in the SI system."""@en ;
 ###  http://emmo.info/emmo#EMMO_faab3f84_e475_4a46_af9c_7d249f0b9aef
 :EMMO_faab3f84_e475_4a46_af9c_7d249f0b9aef rdf:type owl:Class ;
                                            rdfs:subClassOf :EMMO_a66427d1_9932_4363_9ec5_7d91f2bfda1e ;
+                                           :EMMO_1f1b164d_ec6a_4faa_8d5e_88bda62316cc "http://qudt.org/vocab/quantitykind/DimensionlessRatio" ;
                                            :EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9 "The class of quantities that are the ratio of two quantities with the same physical dimensionality."@en ;
                                            :EMMO_b432d2d5_25f4_4165_99c5_5935a7763c1a """refractive index,
 volume fraction,


### PR DESCRIPTION
some qudtReference assignments are missing or have errors

added:
```
emmo:PositionVector 		qudt:PositionVector
emmo:ElectricPotential 		qudt:ElectricPotential
emmo:CelciusTemperature		qudt:CelciusTemperature
emmo:ISQDimensionlessQuantity 	qudt:Dimensionless
emmo:AreaDensity 		qudt:SurfaceDensity
emmo:Length 			qudt:Length
emmo:RatioQuantity 		qudt:DimensionlessRatio
emmo:Vergence 			qudt:Curvature
```

changed:
```
emmo:LuminousIntensity 		qudt:LuminousIntensity
```

protocol added:
```
emmo:ThermodynamicTemperature	qudt:ThermodynamicTemperature
emmo:Time			qudt:Time
```