### PR TITLE
Corrected IRIs in emmo top

### DIFF
--- a/top/top.ttl
+++ b/top/top.ttl
@@ -396,7 +396,7 @@ skos:prefLabel rdf:type owl:AnnotationProperty ;
 
 
 ###  http://emmo.info/emmo#EMMO_5022e4cb_125f_429d_8556_c3e635c561f2
-:EMMO_5022e4cb_125f_429d_8556_c3e635c561f2> rdf:type owl:ObjectProperty ;
+:EMMO_5022e4cb_125f_429d_8556_c3e635c561f2 rdf:type owl:ObjectProperty ;
                                                              rdfs:subPropertyOf :EMMO_7afbed84_7593_4a23_bd88_9d9c6b04e8f6 ;
                                                              rdfs:range :EMMO_eb3a768e_d53e_4be9_a23b_0714833c36de ;
                                                              skos:prefLabel "hasTemporalItemPart"@en .

--- a/top/top.ttl
+++ b/top/top.ttl
@@ -10,9 +10,9 @@
 
 <http://emmo.info/emmo/top> rdf:type owl:Ontology ;
                              owl:versionIRI <http://emmo.info/emmo/1.0.0-beta3/top> ;
-                             dcterms:abstract """Introduces the fundamental mereotopological concepts of EMMO and their relations with the real world objects that they represent. EMMO uses mereotopology as the ground for all the subsequent ontology modules.  
+                             dcterms:abstract """Introduces the fundamental mereotopological concepts of EMMO and their relations with the real world objects that they represent. EMMO uses mereotopology as the ground for all the subsequent ontology modules.
 
-The concept of topological connection is used to define the first distinction between ontology entities namely the 'Item' and 'Collection' classes.  Items are causally self-connected objects, while collections are causally disconnected.  
+The concept of topological connection is used to define the first distinction between ontology entities namely the 'Item' and 'Collection' classes.  Items are causally self-connected objects, while collections are causally disconnected.
 
 Quantum mereology is represented by the 'Quantum' class. This module introduces also the fundamental mereotopological relations used to distinguish between space and time dimensions.
 
@@ -71,7 +71,7 @@ A definition uses entities in an ontological system to identify other derivate o
 ###  http://emmo.info/emmo#EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9
 :EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9 rdf:type owl:AnnotationProperty ;
                                            rdfs:comment """Short enlightening explanation of an ontological entity aimed to facilitate the connection (interpretation) between the ontological concept and a real-world object.
-An elucidation provides the meta-ontological semiotic relation that connects an entity within the ontology, to a real-world entity outside the ontology. 
+An elucidation provides the meta-ontological semiotic relation that connects an entity within the ontology, to a real-world entity outside the ontology.
 This process is subjective, depends on the agent that draws this connection (e.g. the EMMO user, a machine), and is independent (outside) from the ontology representational capabilities."""@en ;
                                            skos:prefLabel "elucidation"@en ;
                                            rdfs:subPropertyOf rdfs:comment ;
@@ -388,15 +388,15 @@ skos:prefLabel rdf:type owl:AnnotationProperty ;
                                            skos:prefLabel "hasSpatialEssentialPart"@en .
 
 
-###  http://emmo.info/emmo#c773cf3b_0810_4d07_bea7_af08cd88538e
-:c773cf3b_0810_4d07_bea7_af08cd88538e rdf:type owl:ObjectProperty ;
+###  http://emmo.info/emmo#EMMO_c773cf3b_0810_4d07_bea7_af08cd88538e
+:EMMO_c773cf3b_0810_4d07_bea7_af08cd88538e rdf:type owl:ObjectProperty ;
                                       rdfs:subPropertyOf :EMMO_7afbed84_7593_4a23_bd88_9d9c6b04e8f6 ;
                                       rdfs:range :EMMO_2d2ecd97_067f_4d0e_950c_d746b7700a31 ;
                                       skos:prefLabel "hasTemporalCollectionPart"@en .
 
 
-###  http://emmo.info/emmo#5022e4cb_125f_429d_8556_c3e635c561f2
-<http://emmo.info/emmo#5022e4cb_125f_429d_8556_c3e635c561f2> rdf:type owl:ObjectProperty ;
+###  http://emmo.info/emmo#EMMO_5022e4cb_125f_429d_8556_c3e635c561f2
+:EMMO_5022e4cb_125f_429d_8556_c3e635c561f2> rdf:type owl:ObjectProperty ;
                                                              rdfs:subPropertyOf :EMMO_7afbed84_7593_4a23_bd88_9d9c6b04e8f6 ;
                                                              rdfs:range :EMMO_eb3a768e_d53e_4be9_a23b_0714833c36de ;
                                                              skos:prefLabel "hasTemporalItemPart"@en .
@@ -482,7 +482,7 @@ The quantum concept recalls the fact that there is lower epistemological limit t
 
 Space and time emerge following the network of causal connections between quantum objects. So quantum objects are adimensional objects, that precede space and time dimensions.
 
-A quantum is the EMMO mereological atomistic entity. 
+A quantum is the EMMO mereological atomistic entity.
 
 To avoid confusion with the concept of atom coming from physics, we will use the expression quantum mereology, instead of atomistic mereology."""@en ;
                                            skos:prefLabel "Quantum"@en .
@@ -514,7 +514,7 @@ To avoid confusion with the concept of atom coming from physics, we will use the
 The union implies that 'EMMO' individuals can only be 'Item' individuals (standing for self-connected world objects) or 'Collection' individuals (standing for a collection of disconnected items).
 Disjointness means that a 'Collection' individual cannot be an 'Item' individual and viceversa, representing the fact that a world object cannot be self-connected and non-self connected at the same time."""@en ,
                                                         """Mereotopology is the logical framework used by the EMMO ontologist to characterize the universe and to provide the definitions to connect world objects to the EMMO concepts.
-For the EMMO ontologist the whole universe is the most comprehensive object. World objects are then sub-parts of the universe. 
+For the EMMO ontologist the whole universe is the most comprehensive object. World objects are then sub-parts of the universe.
 The fundamental distinction between world objects, upon which the EMMO is based, is self-connectedness: a world object can be self-connected xor not self-connected.
 Parthood relations do not change dimensionality of the world object: every part of a world object is another world object and always retains a 4D dimensionality character.
 The smallest part of a world object (i.e. a part that has no proper parts) is called a 'Quantum' individual. Quantum individuals are the fundamental causal constituents of the universe. They are no-dimensional, and their aggregation makes 4D objects emerge  from their causal structure.
@@ -563,7 +563,7 @@ Physical object temporal parts must be always self-connected. In other words, a 
                                                                  :EMMO_c5ddfdba_c074_4aa4_ad6b_1ac4942d300d
                                                                ) ;
                                            :EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9 "The class of individuals standing for world self-connected objects."@en ;
-                                           rdfs:comment """A world object is self-connected if any two parts that make up the whole are topologically connected to each other. 
+                                           rdfs:comment """A world object is self-connected if any two parts that make up the whole are topologically connected to each other.
 
 In the EMMO, topological connectivity is based on causality.
 


### PR DESCRIPTION
Added "EMMO_" prefix to two IRIs in EMMO top: "hasTemporalCollectionPart" and "hasTemporalItemPart".

These are not used in any other parts of EMMO, so no conflicts are created within this repo.
