### PR TITLE
Moved Representation from chemistry.ttl to perceptual.ttl

### DIFF
--- a/disciplines/chemistry.ttl
+++ b/disciplines/chemistry.ttl
@@ -9,23 +9,23 @@
 @base <http://emmo.info/emmo/disciplines/chemistry> .
 
 <http://emmo.info/emmo/disciplines/chemistry> rdf:type owl:Ontology ;
-                                             owl:versionIRI <http://emmo.info/emmo/1.0.0-beta4/disciplines/chemistry> ;
-                                             owl:imports <http://emmo.info/emmo/1.0.0-beta4/disciplines/isq> ;
-                                             dcterms:abstract "The chemistry module populates the physicalistic perspective with materials subclasses categorised according to modern applied chemistry."@en ;
-                                             dcterms:contributor "Access, DE" ,
-                                                                 "Fraunhofer IWM, DE" ,
-                                                                 "Goldbeck Consulting Ltd (UK)" ,
-                                                                 "SINTEF, NO" ,
-                                                                 "University of Bologna, IT" ;
-                                             dcterms:creator "Adham Hashibon" ,
-                                                             "Emanuele Ghedini" ,
-                                                             "Georg Schmitz" ,
-                                                             "Gerhard Goldbeck" ,
-                                                             "Jesper Friis" ;
-                                             dcterms:license "https://creativecommons.org/licenses/by/4.0/legalcode" ;
-                                             dcterms:publisher "EMMC ASBL" ;
-                                             dcterms:title "Chemistry"@en ;
-                                             rdfs:comment """Contacts:
+                                               owl:versionIRI <http://emmo.info/emmo/1.0.0-beta4/disciplines/chemistry> ;
+                                               owl:imports <http://emmo.info/emmo/1.0.0-beta4/disciplines/isq> ;
+                                               dcterms:abstract "The chemistry module populates the physicalistic perspective with materials subclasses categorised according to modern applied chemistry."@en ;
+                                               dcterms:contributor "Access, DE" ,
+                                                                   "Fraunhofer IWM, DE" ,
+                                                                   "Goldbeck Consulting Ltd (UK)" ,
+                                                                   "SINTEF, NO" ,
+                                                                   "University of Bologna, IT" ;
+                                               dcterms:creator "Adham Hashibon" ,
+                                                               "Emanuele Ghedini" ,
+                                                               "Georg Schmitz" ,
+                                                               "Gerhard Goldbeck" ,
+                                                               "Jesper Friis" ;
+                                               dcterms:license "https://creativecommons.org/licenses/by/4.0/legalcode" ;
+                                               dcterms:publisher "EMMC ASBL" ;
+                                               dcterms:title "Chemistry"@en ;
+                                               rdfs:comment """Contacts:
 Gerhard Goldbeck
 Goldbeck Consulting Ltd (UK)
 email: gerhard@goldbeck-consulting.com
@@ -33,8 +33,8 @@ email: gerhard@goldbeck-consulting.com
 Emanuele Ghedini
 University of Bologna (IT)
 email: emanuele.ghedini@unibo.it"""@en ,
-                                                          "The EMMO requires FacT++ reasoner plugin in order to visualize all inferences and class hierarchy (ctrl+R hotkey in Protege)."@en ;
-                                             owl:versionInfo "1.0.0-beta4" .
+                                                            "The EMMO requires FacT++ reasoner plugin in order to visualize all inferences and class hierarchy (ctrl+R hotkey in Protege)."@en ;
+                                               owl:versionInfo "1.0.0-beta4" .
 
 #################################################################
 #    Classes
@@ -360,10 +360,7 @@ Sodium Chloride""" ;
 
 
 ###  http://emmo.info/emmo#EMMO_eb7de1a1_c30e_4f0d_94c6_fe70414d7e61
-:EMMO_eb7de1a1_c30e_4f0d_94c6_fe70414d7e61 rdf:type owl:Class ;
-                                           rdfs:subClassOf :EMMO_c74da218_9147_4f03_92d1_8894abca55f3 ;
-                                           :EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9 "A graphical object aimed to represent schematically the conceptual, tempral or spatial structure of another object." ;
-                                           skos:prefLabel "Representation"@en .
+:EMMO_eb7de1a1_c30e_4f0d_94c6_fe70414d7e61 rdf:type owl:Class .
 
 
 ###  http://emmo.info/emmo#EMMO_ecc4efe9_77a2_47e3_8190_f9a883d54ac6

--- a/perspectives/perceptual.ttl
+++ b/perspectives/perceptual.ttl
@@ -9,20 +9,20 @@
 @base <http://emmo.info/emmo/perspectives/perceptual> .
 
 <http://emmo.info/emmo/perspectives/perceptual> rdf:type owl:Ontology ;
-                                           owl:versionIRI <http://emmo.info/emmo/1.0.0-beta4/perspectives/perceptual> ;
-                                           owl:imports <http://emmo.info/emmo/1.0.0-beta4/perspectives/perspective> ;
-                                           dcterms:abstract """Defines the perceptual perspective, which which categorises real world objects according to how they are percieved by an user as a recognisable pattern in space or time. 
+                                                 owl:versionIRI <http://emmo.info/emmo/1.0.0-beta4/perspectives/perceptual> ;
+                                                 owl:imports <http://emmo.info/emmo/1.0.0-beta4/perspectives/perspective> ;
+                                                 dcterms:abstract """Defines the perceptual perspective, which categorises real world objects according to how they are percieved by an user as a recognisable pattern in space or time. 
 
 The perceptual module includes formal languages, pictures, geometry, mathematics and sounds. Phenomenic objects can be used in a semiotic process as signs."""@en ;
-                                           dcterms:contributor "Adham Hashibon, Fraunhofer IWM, DE" ,
-                                                               "Georg Schmitz, Access, DE" ,
-                                                               "Gerhard Goldbeck, Goldbeck Consulting Ltd (UK)" ,
-                                                               "Jesper Friis, SINTEF, NO" ;
-                                           dcterms:creator "Emanuele Ghedini, University of Bologna, IT" ;
-                                           dcterms:license "https://creativecommons.org/licenses/by/4.0/legalcode" ;
-                                           dcterms:publisher "EMMC ASBL" ;
-                                           dcterms:title "Perceptual"@en ;
-                                           rdfs:comment """Contacts:
+                                                 dcterms:contributor "Adham Hashibon, Fraunhofer IWM, DE" ,
+                                                                     "Georg Schmitz, Access, DE" ,
+                                                                     "Gerhard Goldbeck, Goldbeck Consulting Ltd (UK)" ,
+                                                                     "Jesper Friis, SINTEF, NO" ;
+                                                 dcterms:creator "Emanuele Ghedini, University of Bologna, IT" ;
+                                                 dcterms:license "https://creativecommons.org/licenses/by/4.0/legalcode" ;
+                                                 dcterms:publisher "EMMC ASBL" ;
+                                                 dcterms:title "Perceptual"@en ;
+                                                 rdfs:comment """Contacts:
 Gerhard Goldbeck
 Goldbeck Consulting Ltd (UK)
 email: gerhard@goldbeck-consulting.com
@@ -30,182 +30,104 @@ email: gerhard@goldbeck-consulting.com
 Emanuele Ghedini
 University of Bologna (IT)
 email: emanuele.ghedini@unibo.it"""@en ,
-                                                        "The EMMO requires FacT++ reasoner plugin in order to visualize all inferences and class hierarchy (ctrl+R hotkey in Protege)."@en ;
-                                           owl:versionInfo "1.0.0-beta4" .
+                                                              "The EMMO requires FacT++ reasoner plugin in order to visualize all inferences and class hierarchy (ctrl+R hotkey in Protege)."@en ;
+                                                 owl:versionInfo "1.0.0-beta4" .
 
 #################################################################
 #    Classes
 #################################################################
 
-###  http://emmo.info/emmo#EMMO_b2a234a8_579a_422c_9305_b8f7e72c76cd
-:EMMO_b2a234a8_579a_422c_9305_b8f7e72c76cd rdf:type owl:Class ;
-                                      rdfs:subClassOf <http://emmo.info/emmo#EMMO_0c576e13_4ee7_4f3d_bfe9_1614243df018> ;
-                                      skos:prefLabel "Circle"@en .
-
-
-###  http://emmo.info/emmo#EMMO_b5957cef_a287_442d_a3ce_fd39f20ba1cd
-:EMMO_b5957cef_a287_442d_a3ce_fd39f20ba1cd rdf:type owl:Class ;
-                                      rdfs:subClassOf :EMMO_c5ae6d8e_6b39_431f_8de4_ae4e357abc04 ;
-                                      :EMMO_b432d2d5_25f4_4165_99c5_5935a7763c1a """A geometrical object can be expressed in many different forms. 
-
-For example, a line can be expressed by:
-a) an equation like y=mx+q, which is both an 'equation' and a 'geometrical'
-b) a line drawn with a pencil on a paper, which is simply a 'graphical' object
-c) a set of axioms, when the properties of a line are inferred by the interpreter reading them, that are both 'graphical' and also 'formula'
-
-The case a) is a geometrical and mathematical, b) is geometrical and pictorial, while c) is geometrical and a composition of idiomatic strings."""@en ;
-                                      <http://emmo.info/emmo#EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9> "A 'graphical' aimed to represent a geometrical concept."@en ;
-                                      skos:prefLabel "Geometrical"@en .
-
-
-###  http://emmo.info/emmo#EMMO_c5ae6d8e_6b39_431f_8de4_ae4e357abc04
-:EMMO_c5ae6d8e_6b39_431f_8de4_ae4e357abc04 rdf:type owl:Class ;
-                                      :EMMO_b432d2d5_25f4_4165_99c5_5935a7763c1a """A cloud.
-A picture.
-A colour gradient on a wall.
-A stain.
-A mail."""@en ;
-                                      <http://emmo.info/emmo#EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9> "A 'Perceptual' which stands for a real world object whose spatiotemporal pattern makes it identifiable by an observer through an optical perception employing the visible part of the electromagnetic spectrum."@en ;
-                                      skos:prefLabel "Visual"@en .
-
-
-###  http://emmo.info/emmo#EMMO_c74da218_9147_4f03_92d1_8894abca55f3
-:EMMO_c74da218_9147_4f03_92d1_8894abca55f3 rdf:type owl:Class ;
-                                      rdfs:subClassOf :EMMO_c5ae6d8e_6b39_431f_8de4_ae4e357abc04 ;
-                                      :EMMO_b432d2d5_25f4_4165_99c5_5935a7763c1a "'Graphical' objects include writings, pictures, sketches ..."@en ;
-                                      <http://emmo.info/emmo#EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9> "A 'Perceptual' which stands for a real world object whose spatial configuration is due to an explicit graphical procedure and shows an identifiable pattern."@en ;
-                                      rdfs:comment "This concept includes only things that are purposely created by an agent."@en ;
-                                      skos:prefLabel "Graphical"@en .
-
-[ rdf:type owl:Axiom ;
-   owl:annotatedSource :EMMO_c74da218_9147_4f03_92d1_8894abca55f3 ;
-   owl:annotatedProperty skos:prefLabel ;
-   owl:annotatedTarget "Graphical"@en ;
-   <http://emmo.info/emmo#EMMO_705f27ae_954c_4f13_98aa_18473fc52b25> "From the Ancient Greek γραφή (graphḗ) which means drawing, painting, writing, a writing, description, and from γράφω (gráphō) which means scratch, carve."@en ;
-   rdfs:comment "The term graphical is used in etymological sense, comprising both writings and visual arts."@en
- ] .
-
-
-###  http://emmo.info/emmo#EMMO_ccdc1a41_6e96_416b_92ec_efe67917434a
-:EMMO_ccdc1a41_6e96_416b_92ec_efe67917434a rdf:type owl:Class ;
-                                      rdfs:subClassOf :EMMO_c74da218_9147_4f03_92d1_8894abca55f3 ;
-                                      <http://emmo.info/emmo#EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9> "An heterogenous object made of different graphical object parts."@en ;
-                                      skos:prefLabel "Document"@en .
-
-[ rdf:type owl:Axiom ;
-   owl:annotatedSource :EMMO_ccdc1a41_6e96_416b_92ec_efe67917434a ;
-   owl:annotatedProperty skos:prefLabel ;
-   owl:annotatedTarget "Document"@en ;
-   <http://emmo.info/emmo#EMMO_705f27ae_954c_4f13_98aa_18473fc52b25> "From Latin documentum, from the verb doceō (“teach”) +‎ -mentum."@en
- ] .
-
-
-###  http://emmo.info/emmo#EMMO_d7bf784a_db94_4dd9_861c_54f262846fbf
-:EMMO_d7bf784a_db94_4dd9_861c_54f262846fbf rdf:type owl:Class ;
-                                      rdfs:subClassOf <http://emmo.info/emmo#EMMO_9268958f_7f54_48ab_a693_febe2645892b> ;
-                                      skos:prefLabel "Sphere"@en .
-
-
-###  http://emmo.info/emmo#EMMO_dd14d055_2db0_4b81_bc97_ef6c2f72b8a0
-:EMMO_dd14d055_2db0_4b81_bc97_ef6c2f72b8a0 rdf:type owl:Class ;
-                                      skos:prefLabel "Gustatory"@en .
-
-
-###  http://emmo.info/emmo#EMMO_e1021593_06da_4237_8a02_29d8f6fef76d
-:EMMO_e1021593_06da_4237_8a02_29d8f6fef76d rdf:type owl:Class ;
-                                      skos:prefLabel "Olfactory"@en .
-
-
 ###  http://emmo.info/emmo#EMMO_0ab0485c_9e5b_4257_a679_90a2dfba5c7c
-<http://emmo.info/emmo#EMMO_0ab0485c_9e5b_4257_a679_90a2dfba5c7c> rdf:type owl:Class ;
-                                                             rdfs:subClassOf :EMMO_b5957cef_a287_442d_a3ce_fd39f20ba1cd ;
-                                                             skos:altLabel "0-manifold"@en ;
-                                                             skos:prefLabel "ZeroManifold"@en .
+:EMMO_0ab0485c_9e5b_4257_a679_90a2dfba5c7c rdf:type owl:Class ;
+                                           rdfs:subClassOf :EMMO_b5957cef_a287_442d_a3ce_fd39f20ba1cd ;
+                                           skos:altLabel "0-manifold"@en ;
+                                           skos:prefLabel "ZeroManifold"@en .
 
 
 ###  http://emmo.info/emmo#EMMO_0c576e13_4ee7_4f3d_bfe9_1614243df018
-<http://emmo.info/emmo#EMMO_0c576e13_4ee7_4f3d_bfe9_1614243df018> rdf:type owl:Class ;
-                                                             rdfs:subClassOf :EMMO_b5957cef_a287_442d_a3ce_fd39f20ba1cd ;
-                                                             skos:altLabel "1-manifold"@en ;
-                                                             skos:prefLabel "OneManifold"@en .
+:EMMO_0c576e13_4ee7_4f3d_bfe9_1614243df018 rdf:type owl:Class ;
+                                           rdfs:subClassOf :EMMO_b5957cef_a287_442d_a3ce_fd39f20ba1cd ;
+                                           skos:altLabel "1-manifold"@en ;
+                                           skos:prefLabel "OneManifold"@en .
 
 
 ###  http://emmo.info/emmo#EMMO_0ef4ff4a_5458_4f2a_b51f_4689d472a3f2
-<http://emmo.info/emmo#EMMO_0ef4ff4a_5458_4f2a_b51f_4689d472a3f2> rdf:type owl:Class ;
-                                                             rdfs:subClassOf <http://emmo.info/emmo#EMMO_0c576e13_4ee7_4f3d_bfe9_1614243df018> ;
-                                                             skos:prefLabel "Curve"@en .
+:EMMO_0ef4ff4a_5458_4f2a_b51f_4689d472a3f2 rdf:type owl:Class ;
+                                           rdfs:subClassOf :EMMO_0c576e13_4ee7_4f3d_bfe9_1614243df018 ;
+                                           skos:prefLabel "Curve"@en .
 
 
 ###  http://emmo.info/emmo#EMMO_1da53c06_9577_4008_8652_272fa3b62be7
-<http://emmo.info/emmo#EMMO_1da53c06_9577_4008_8652_272fa3b62be7> rdf:type owl:Class ;
-                                                             rdfs:subClassOf :EMMO_c74da218_9147_4f03_92d1_8894abca55f3 ;
-                                                             :EMMO_b432d2d5_25f4_4165_99c5_5935a7763c1a """A drawing of a cat.
+:EMMO_1da53c06_9577_4008_8652_272fa3b62be7 rdf:type owl:Class ;
+                                           rdfs:subClassOf :EMMO_c74da218_9147_4f03_92d1_8894abca55f3 ;
+                                           :EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9 "A 'Graphical' that stands for a real world object that shows a recognizable pictorial pattern without being necessarily associated to a symbolic language."@en ;
+                                           :EMMO_b432d2d5_25f4_4165_99c5_5935a7763c1a """A drawing of a cat.
 A circle on a paper sheet.
 The Mona Lisa."""@en ;
-                                                             <http://emmo.info/emmo#EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9> "A 'Graphical' that stands for a real world object that shows a recognizable pictorial pattern without being necessarily associated to a symbolic language."@en ;
-                                                             skos:prefLabel "Pictorial"@en .
+                                           skos:prefLabel "Pictorial"@en .
 
 
 ###  http://emmo.info/emmo#EMMO_25f5ca8e_8f7f_44d8_a392_bd3fe8894458
-<http://emmo.info/emmo#EMMO_25f5ca8e_8f7f_44d8_a392_bd3fe8894458> rdf:type owl:Class ;
-                                                             rdfs:subClassOf <http://emmo.info/emmo#EMMO_9268958f_7f54_48ab_a693_febe2645892b> ;
-                                                             skos:prefLabel "Plane"@en .
-
-
-###  http://emmo.info/emmo#EMMO_3e309118_e8b7_4021_80f4_642d2df65d94
-<http://emmo.info/emmo#EMMO_3e309118_e8b7_4021_80f4_642d2df65d94> rdf:type owl:Class ;
-                                                             rdfs:subClassOf <http://emmo.info/emmo#EMMO_0c576e13_4ee7_4f3d_bfe9_1614243df018> ;
-                                                             skos:prefLabel "Line"@en .
+:EMMO_25f5ca8e_8f7f_44d8_a392_bd3fe8894458 rdf:type owl:Class ;
+                                           rdfs:subClassOf :EMMO_9268958f_7f54_48ab_a693_febe2645892b ;
+                                           skos:prefLabel "Plane"@en .
 
 
 ###  http://emmo.info/emmo#EMMO_39362460_2a97_4367_8f93_0418c2ac9a08
-<http://emmo.info/emmo#EMMO_39362460_2a97_4367_8f93_0418c2ac9a08> rdf:type owl:Class ;
-                                                             rdfs:subClassOf <http://emmo.info/emmo#EMMO_0ab0485c_9e5b_4257_a679_90a2dfba5c7c> ;
-                                                             skos:prefLabel "Point"@en .
+:EMMO_39362460_2a97_4367_8f93_0418c2ac9a08 rdf:type owl:Class ;
+                                           rdfs:subClassOf :EMMO_0ab0485c_9e5b_4257_a679_90a2dfba5c7c ;
+                                           skos:prefLabel "Point"@en .
+
+
+###  http://emmo.info/emmo#EMMO_3e309118_e8b7_4021_80f4_642d2df65d94
+:EMMO_3e309118_e8b7_4021_80f4_642d2df65d94 rdf:type owl:Class ;
+                                           rdfs:subClassOf :EMMO_0c576e13_4ee7_4f3d_bfe9_1614243df018 ;
+                                           skos:prefLabel "Line"@en .
+
+
+###  http://emmo.info/emmo#EMMO_46f0f8df_4dc6_418f_8036_10427a3a288e
+:EMMO_46f0f8df_4dc6_418f_8036_10427a3a288e rdf:type owl:Class ;
+                                           rdfs:subClassOf :EMMO_b5957cef_a287_442d_a3ce_fd39f20ba1cd ;
+                                           skos:altLabel "3-manifold"@en ;
+                                           skos:prefLabel "ThreeManifold"@en .
 
 
 ###  http://emmo.info/emmo#EMMO_4b3afb22_27cf_4ce3_88bc_492bfccb546b
-<http://emmo.info/emmo#EMMO_4b3afb22_27cf_4ce3_88bc_492bfccb546b> rdf:type owl:Class ;
-                                                             :EMMO_b432d2d5_25f4_4165_99c5_5935a7763c1a """When we use the term 'sound' what are we referring to? The EMMO identifis a sound as the physical object that can be heard by the observer (more exactly, by the sensor of the observer). 
+:EMMO_4b3afb22_27cf_4ce3_88bc_492bfccb546b rdf:type owl:Class ;
+                                           :EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9 "A 'Perceptual' which stands for a real world object whose spatiotemporal pattern makes it identifiable by an observer as a sound."@en ;
+                                           :EMMO_b432d2d5_25f4_4165_99c5_5935a7763c1a """When we use the term 'sound' what are we referring to? The EMMO identifis a sound as the physical object that can be heard by the observer (more exactly, by the sensor of the observer). 
 
 In this sense, a sound (which is an acoustical object) is to be identified as the air region that manifests the sound wave and is able to be perceived by an observer. In case the wave is travelling through water or steel, then these other media regions are the sounds.
 
 If the waveform is travelling through a cable as electronic signal (analog or digital) it is no more a sound, since it cannot be perceived by an observer as an acoustical object. This electrical waveform (or digital packet) is another physical that may stand for a sound if interpreted by a device (e.g. an amplifier, a DA converter)."""@en ;
-                                                             <http://emmo.info/emmo#EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9> "A 'Perceptual' which stands for a real world object whose spatiotemporal pattern makes it identifiable by an observer as a sound."@en ;
-                                                             rdfs:comment "'acoustical' refers to the perception mechanism of the observer that can occur through a microphone, a ear."@en ;
-                                                             skos:altLabel "Sound"@en ;
-                                                             skos:prefLabel "Auditory"@en .
-
-
-###  http://emmo.info/emmo#EMMO_46f0f8df_4dc6_418f_8036_10427a3a288e
-<http://emmo.info/emmo#EMMO_46f0f8df_4dc6_418f_8036_10427a3a288e> rdf:type owl:Class ;
-                                                             rdfs:subClassOf :EMMO_b5957cef_a287_442d_a3ce_fd39f20ba1cd ;
-                                                             skos:altLabel "3-manifold"@en ;
-                                                             skos:prefLabel "ThreeManifold"@en .
+                                           rdfs:comment "'acoustical' refers to the perception mechanism of the observer that can occur through a microphone, a ear."@en ;
+                                           skos:altLabel "Sound"@en ;
+                                           skos:prefLabel "Auditory"@en .
 
 
 ###  http://emmo.info/emmo#EMMO_5f278af9_8593_4e27_a717_ccc9e07a0ddf
-<http://emmo.info/emmo#EMMO_5f278af9_8593_4e27_a717_ccc9e07a0ddf> rdf:type owl:Class ;
-                                                             rdfs:subClassOf <http://emmo.info/emmo#EMMO_46f0f8df_4dc6_418f_8036_10427a3a288e> ;
-                                                             skos:prefLabel "EuclideanSpace"@en .
+:EMMO_5f278af9_8593_4e27_a717_ccc9e07a0ddf rdf:type owl:Class ;
+                                           rdfs:subClassOf :EMMO_46f0f8df_4dc6_418f_8036_10427a3a288e ;
+                                           skos:prefLabel "EuclideanSpace"@en .
 
 
 ###  http://emmo.info/emmo#EMMO_649bf97b_4397_4005_90d9_219755d92e34
-<http://emmo.info/emmo#EMMO_649bf97b_4397_4005_90d9_219755d92e34> rdf:type owl:Class ;
-                                                             owl:equivalentClass [ rdf:type owl:Class ;
-                                                                                   owl:unionOf ( :EMMO_c5ae6d8e_6b39_431f_8de4_ae4e357abc04
-                                                                                                 :EMMO_dd14d055_2db0_4b81_bc97_ef6c2f72b8a0
-                                                                                                 :EMMO_e1021593_06da_4237_8a02_29d8f6fef76d
-                                                                                                 <http://emmo.info/emmo#EMMO_4b3afb22_27cf_4ce3_88bc_492bfccb546b>
-                                                                                                 <http://emmo.info/emmo#EMMO_8f207971_aaab_48dc_a10d_55a6b4331410>
-                                                                                               )
-                                                                                 ] ;
-                                                             rdfs:subClassOf <http://emmo.info/emmo#EMMO_49267eba_5548_4163_8f36_518d65b583f9> ;
-                                                             :EMMO_b432d2d5_25f4_4165_99c5_5935a7763c1a """A line scratched on a surface.
+:EMMO_649bf97b_4397_4005_90d9_219755d92e34 rdf:type owl:Class ;
+                                           owl:equivalentClass [ rdf:type owl:Class ;
+                                                                 owl:unionOf ( :EMMO_4b3afb22_27cf_4ce3_88bc_492bfccb546b
+                                                                               :EMMO_8f207971_aaab_48dc_a10d_55a6b4331410
+                                                                               :EMMO_c5ae6d8e_6b39_431f_8de4_ae4e357abc04
+                                                                               :EMMO_dd14d055_2db0_4b81_bc97_ef6c2f72b8a0
+                                                                               :EMMO_e1021593_06da_4237_8a02_29d8f6fef76d
+                                                                             )
+                                                               ] ;
+                                           rdfs:subClassOf :EMMO_49267eba_5548_4163_8f36_518d65b583f9 ;
+                                           :EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9 "The class of 'Physical' individuals which stand for real world objects that can stimulate a perception (e.g. a retina impression) into the ontologist and that are categorized accordingly to human perception mechanisms."@en ;
+                                           :EMMO_b432d2d5_25f4_4165_99c5_5935a7763c1a """A line scratched on a surface.
 A sound.
 A smell.
 The word 'cat' and the sound of the word 'cat' (the first one is graphical and the second acoustical)."""@en ,
-                                                                                                   """The meta-semiotic process:
+                                                                                      """The meta-semiotic process:
 I see a cloud in the sky. Since I'm an EMMO ontologist, I create an individual named Cloud under the 'Perceptual' class, meaning that I recognize the cloud as an object thanks to a specific perceptual channel (e.g. through my eyes). This semiotic process occurs at meta-level: it's how I use the EMMO as tool for a direct representation of the world, understandable by others ontologists.
 
 The semiotic process within EMMO:
@@ -219,47 +141,132 @@ I use the EMMO to record this experience by declaring:
 So, the Perceptual class is here to categorized real-world objects at meta-level using common perceptual channels, for practical ontology usage.
 
 We could have represented the word \"elephant\" within a physicalistic approach, by identifying it as a pressure wave in the air."""@en ;
-                                                             <http://emmo.info/emmo#EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9> "The class of 'Physical' individuals which stand for real world objects that can stimulate a perception (e.g. a retina impression) into the ontologist and that are categorized accordingly to human perception mechanisms."@en ;
-                                                             rdfs:comment """This class is the most general superclass for the categorization of real world objects that are recognizable by the ontologist through a specific perception mechanism. This perspective is based on human characterization of perceptions.
+                                           rdfs:comment """This class is the most general superclass for the categorization of real world objects that are recognizable by the ontologist through a specific perception mechanism. This perspective is based on human characterization of perceptions.
 
 In other words, a 'Perceptual' is a meta-object, meaning that is addressed by the ontologist (the meta-interpreter) in a semiotic process occurring outside the EMMO. The 'Perceptual' branch is here to facilitate the connection between an individual and the real-world object for which it stands for.
 
 A 'Perceptual' can stand for another object in an EMMO described semiotic process (acting as sign or as object), just like a word on a paper (the perceptual object) may refer semiotically to another object. However, a perceptual is not necessarily a 'Sign' (e.g. a line sketched on a blackboard is a recognizable 'Perceptual' but it may stand for nothing).
 
 A 'Perceptual' becomes an 'Object', when it is part of a 'Semiotic' process described by the ontologist within the EMMO, and it's done always specifying for which interpreter this relation occurs."""@en ;
-                                                             skos:prefLabel "Perceptual"@en .
+                                           skos:prefLabel "Perceptual"@en .
 
 [ rdf:type owl:Axiom ;
-   owl:annotatedSource <http://emmo.info/emmo#EMMO_649bf97b_4397_4005_90d9_219755d92e34> ;
+   owl:annotatedSource :EMMO_649bf97b_4397_4005_90d9_219755d92e34 ;
    owl:annotatedProperty skos:prefLabel ;
    owl:annotatedTarget "Perceptual"@en ;
-   <http://emmo.info/emmo#EMMO_705f27ae_954c_4f13_98aa_18473fc52b25> "From Latin percipiō, past participle perceptus (“take hold of, obtain, receive, observe”), from per (“by, through”) + capiō (“to take”)."@en
+   :EMMO_705f27ae_954c_4f13_98aa_18473fc52b25 "From Latin percipiō, past participle perceptus (“take hold of, obtain, receive, observe”), from per (“by, through”) + capiō (“to take”)."@en
  ] .
 
 
-###  http://emmo.info/emmo#EMMO_8f207971_aaab_48dc_a10d_55a6b4331410
-<http://emmo.info/emmo#EMMO_8f207971_aaab_48dc_a10d_55a6b4331410> rdf:type owl:Class ;
-                                                             skos:prefLabel "Somatosensory"@en .
-
-
 ###  http://emmo.info/emmo#EMMO_86060335_31c2_4820_b433_27c64aea0366
-<http://emmo.info/emmo#EMMO_86060335_31c2_4820_b433_27c64aea0366> rdf:type owl:Class ;
-                                                             rdfs:subClassOf <http://emmo.info/emmo#EMMO_9268958f_7f54_48ab_a693_febe2645892b> ;
-                                                             skos:prefLabel "Torus"@en .
+:EMMO_86060335_31c2_4820_b433_27c64aea0366 rdf:type owl:Class ;
+                                           rdfs:subClassOf :EMMO_9268958f_7f54_48ab_a693_febe2645892b ;
+                                           skos:prefLabel "Torus"@en .
+
+
+###  http://emmo.info/emmo#EMMO_8f207971_aaab_48dc_a10d_55a6b4331410
+:EMMO_8f207971_aaab_48dc_a10d_55a6b4331410 rdf:type owl:Class ;
+                                           skos:prefLabel "Somatosensory"@en .
 
 
 ###  http://emmo.info/emmo#EMMO_9268958f_7f54_48ab_a693_febe2645892b
-<http://emmo.info/emmo#EMMO_9268958f_7f54_48ab_a693_febe2645892b> rdf:type owl:Class ;
-                                                             rdfs:subClassOf :EMMO_b5957cef_a287_442d_a3ce_fd39f20ba1cd ;
-                                                             skos:altLabel "2-manifold"@en ;
-                                                             skos:prefLabel "TwoManifold"@en .
+:EMMO_9268958f_7f54_48ab_a693_febe2645892b rdf:type owl:Class ;
+                                           rdfs:subClassOf :EMMO_b5957cef_a287_442d_a3ce_fd39f20ba1cd ;
+                                           skos:altLabel "2-manifold"@en ;
+                                           skos:prefLabel "TwoManifold"@en .
+
+
+###  http://emmo.info/emmo#EMMO_b2a234a8_579a_422c_9305_b8f7e72c76cd
+:EMMO_b2a234a8_579a_422c_9305_b8f7e72c76cd rdf:type owl:Class ;
+                                           rdfs:subClassOf :EMMO_0c576e13_4ee7_4f3d_bfe9_1614243df018 ;
+                                           skos:prefLabel "Circle"@en .
+
+
+###  http://emmo.info/emmo#EMMO_b5957cef_a287_442d_a3ce_fd39f20ba1cd
+:EMMO_b5957cef_a287_442d_a3ce_fd39f20ba1cd rdf:type owl:Class ;
+                                           rdfs:subClassOf :EMMO_c5ae6d8e_6b39_431f_8de4_ae4e357abc04 ;
+                                           :EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9 "A 'graphical' aimed to represent a geometrical concept."@en ;
+                                           :EMMO_b432d2d5_25f4_4165_99c5_5935a7763c1a """A geometrical object can be expressed in many different forms. 
+
+For example, a line can be expressed by:
+a) an equation like y=mx+q, which is both an 'equation' and a 'geometrical'
+b) a line drawn with a pencil on a paper, which is simply a 'graphical' object
+c) a set of axioms, when the properties of a line are inferred by the interpreter reading them, that are both 'graphical' and also 'formula'
+
+The case a) is a geometrical and mathematical, b) is geometrical and pictorial, while c) is geometrical and a composition of idiomatic strings."""@en ;
+                                           skos:prefLabel "Geometrical"@en .
+
+
+###  http://emmo.info/emmo#EMMO_c5ae6d8e_6b39_431f_8de4_ae4e357abc04
+:EMMO_c5ae6d8e_6b39_431f_8de4_ae4e357abc04 rdf:type owl:Class ;
+                                           :EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9 "A 'Perceptual' which stands for a real world object whose spatiotemporal pattern makes it identifiable by an observer through an optical perception employing the visible part of the electromagnetic spectrum."@en ;
+                                           :EMMO_b432d2d5_25f4_4165_99c5_5935a7763c1a """A cloud.
+A picture.
+A colour gradient on a wall.
+A stain.
+A mail."""@en ;
+                                           skos:prefLabel "Visual"@en .
+
+
+###  http://emmo.info/emmo#EMMO_c74da218_9147_4f03_92d1_8894abca55f3
+:EMMO_c74da218_9147_4f03_92d1_8894abca55f3 rdf:type owl:Class ;
+                                           rdfs:subClassOf :EMMO_c5ae6d8e_6b39_431f_8de4_ae4e357abc04 ;
+                                           :EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9 "A 'Perceptual' which stands for a real world object whose spatial configuration is due to an explicit graphical procedure and shows an identifiable pattern."@en ;
+                                           :EMMO_b432d2d5_25f4_4165_99c5_5935a7763c1a "'Graphical' objects include writings, pictures, sketches ..."@en ;
+                                           rdfs:comment "This concept includes only things that are purposely created by an agent."@en ;
+                                           skos:prefLabel "Graphical"@en .
+
+[ rdf:type owl:Axiom ;
+   owl:annotatedSource :EMMO_c74da218_9147_4f03_92d1_8894abca55f3 ;
+   owl:annotatedProperty skos:prefLabel ;
+   owl:annotatedTarget "Graphical"@en ;
+   :EMMO_705f27ae_954c_4f13_98aa_18473fc52b25 "From the Ancient Greek γραφή (graphḗ) which means drawing, painting, writing, a writing, description, and from γράφω (gráphō) which means scratch, carve."@en ;
+   rdfs:comment "The term graphical is used in etymological sense, comprising both writings and visual arts."@en
+ ] .
+
+
+###  http://emmo.info/emmo#EMMO_ccdc1a41_6e96_416b_92ec_efe67917434a
+:EMMO_ccdc1a41_6e96_416b_92ec_efe67917434a rdf:type owl:Class ;
+                                           rdfs:subClassOf :EMMO_c74da218_9147_4f03_92d1_8894abca55f3 ;
+                                           :EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9 "An heterogenous object made of different graphical object parts."@en ;
+                                           skos:prefLabel "Document"@en .
+
+[ rdf:type owl:Axiom ;
+   owl:annotatedSource :EMMO_ccdc1a41_6e96_416b_92ec_efe67917434a ;
+   owl:annotatedProperty skos:prefLabel ;
+   owl:annotatedTarget "Document"@en ;
+   :EMMO_705f27ae_954c_4f13_98aa_18473fc52b25 "From Latin documentum, from the verb doceō (“teach”) +‎ -mentum."@en
+ ] .
+
+
+###  http://emmo.info/emmo#EMMO_d7bf784a_db94_4dd9_861c_54f262846fbf
+:EMMO_d7bf784a_db94_4dd9_861c_54f262846fbf rdf:type owl:Class ;
+                                           rdfs:subClassOf :EMMO_9268958f_7f54_48ab_a693_febe2645892b ;
+                                           skos:prefLabel "Sphere"@en .
+
+
+###  http://emmo.info/emmo#EMMO_dd14d055_2db0_4b81_bc97_ef6c2f72b8a0
+:EMMO_dd14d055_2db0_4b81_bc97_ef6c2f72b8a0 rdf:type owl:Class ;
+                                           skos:prefLabel "Gustatory"@en .
+
+
+###  http://emmo.info/emmo#EMMO_e1021593_06da_4237_8a02_29d8f6fef76d
+:EMMO_e1021593_06da_4237_8a02_29d8f6fef76d rdf:type owl:Class ;
+                                           skos:prefLabel "Olfactory"@en .
+
+
+###  http://emmo.info/emmo#EMMO_eb7de1a1_c30e_4f0d_94c6_fe70414d7e61
+:EMMO_eb7de1a1_c30e_4f0d_94c6_fe70414d7e61 rdf:type owl:Class ;
+                                           rdfs:subClassOf :EMMO_c74da218_9147_4f03_92d1_8894abca55f3 ;
+                                           :EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9 "A graphical object aimed to represent schematically the conceptual, tempral or spatial structure of another object." ;
+                                           skos:prefLabel "Representation"@en .
 
 
 #################################################################
 #    Annotations
 #################################################################
 
-<http://emmo.info/emmo#EMMO_98ada9d8_f1c8_4f13_99b5_d890f5354152> rdfs:comment "This perspective specify elementary objects as from the Standard Model of Particles."@en .
+:EMMO_98ada9d8_f1c8_4f13_99b5_d890f5354152 rdfs:comment "This perspective specify elementary objects as from the Standard Model of Particles."@en .
 
 
 ###  Generated by the OWL API (version 4.5.9.2019-02-01T07:24:44Z) https://github.com/owlcs/owlapi


### PR DESCRIPTION
- Moved Representation from chemistry.ttl to perceptual.ttl
 - Fixed typo in ontology annotation of perceptual.ttl.
