### PR TITLE
Corrected IRI of hasInput

### DIFF
--- a/multiperspective/workflow.ttl
+++ b/multiperspective/workflow.ttl
@@ -74,8 +74,8 @@
                                            skos:prefLabel "hasCollaborationWith"@en .
 
 
-###  http://emmo.info/emmo/perspectives/manufacturing#EMMO_36e69413_8c59_4799_946c_10b05d266e22
-<http://emmo.info/emmo/perspectives/manufacturing#EMMO_36e69413_8c59_4799_946c_10b05d266e22> rdf:type owl:ObjectProperty ;
+###  http://emmo.info/emmo#EMMO_36e69413_8c59_4799_946c_10b05d266e22
+<http://emmo.info/emmo#EMMO_36e69413_8c59_4799_946c_10b05d266e22> rdf:type owl:ObjectProperty ;
                                                                                              rdfs:subPropertyOf :EMMO_53e5b1e1_6026_4ddc_8a4a_3aaaa5fdbdb7 ;
                                                                                              rdfs:domain :EMMO_43e9a05d_98af_41b4_92f6_00f79a09bfce ;
                                                                                              :EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9 "The input of an intentional process."@en ;


### PR DESCRIPTION
Closes #208 

Updated the IRI for hasInput from `http://emmo.info/emmo/perspectives/manufacturing#EMMO_36e69413_8c59_4799_946c_10b05d266e22` to `http://emmo.info/emmo#EMMO_36e69413_8c59_4799_946c_10b05d266e22`.

Note that this might create problems for people relying on the former IRI. Do you think is a problem? If so, we could keep the old IRI, making it equivalent to the new one and give it an owl:deprecated annotation.
