### PR TITLE
add missing electrochemistry domain units

### DIFF
--- a/disciplines/units/noncoherentsiunits.ttl
+++ b/disciplines/units/noncoherentsiunits.ttl
@@ -34,6 +34,38 @@ We kindly acknowledge NIST for reusing their content, including the selection of
 #    Classes
 #################################################################
 
+###  http://emmo.info/emmo#SquareMetrePerGram
+emmo:SquareMetrePerGram rdf:type owl:Class ;
+                                               rdfs:subClassOf emmo:EMMO_4817e479_e401_437e_a49b_54540b93d2a1 ,
+                                                               emmo:EMMO_60b78cc3_6011_4134_95ab_956f56d4bdc1 ,
+                                                               [ rdf:type owl:Restriction ;
+                                                                 owl:onProperty emmo:EMMO_8189b42e_0995_423a_a26c_51168b27c3cf ;
+                                                                 owl:hasValue "1000.0"^^xsd:double
+                                                               ] ,
+                                                               [ rdf:type owl:Restriction ;
+                                                                 owl:onProperty emmo:EMMO_d088a3cb_d3e3_4eb2_9897_00aef0cb00cd ;
+                                                                 owl:hasValue "0.0"^^xsd:double
+                                                               ] ;
+                                               emmo:EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9 "a unit in the category of specific area"@en ;
+                                               skos:prefLabel "SquareMetrePerGram"@en .
+
+
+###  http://emmo.info/emmo#AmperePerGram
+emmo:AmperePerGram rdf:type owl:Class ;
+                                               rdfs:subClassOf emmo:EMMO_60b78cc3_6011_4134_95ab_956f56d4bdc1 ,
+                                                               emmo:EMMO_73be8825_e9a7_41d0_956e_b58060e5d5ac ,
+                                                               [ rdf:type owl:Restriction ;
+                                                                 owl:onProperty emmo:EMMO_8189b42e_0995_423a_a26c_51168b27c3cf ;
+                                                                 owl:hasValue "1000.0"^^xsd:double
+                                                               ] ,
+                                                               [ rdf:type owl:Restriction ;
+                                                                 owl:onProperty emmo:EMMO_d088a3cb_d3e3_4eb2_9897_00aef0cb00cd ;
+                                                                 owl:hasValue "0.0"^^xsd:double
+                                                               ] ;
+                                               emmo:EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9 "a unit of electric current per mass"@en ;
+                                               skos:prefLabel "AmperePerGram"@en .
+
+
 ###  http://emmo.info/emmo#AmperePerCentiMetre
 emmo:AmperePerCentiMetre rdf:type owl:Class ;
                          rdfs:subClassOf emmo:EMMO_60b78cc3_6011_4134_95ab_956f56d4bdc1 ,

--- a/disciplines/units/prefixedunits.ttl
+++ b/disciplines/units/prefixedunits.ttl
@@ -34,6 +34,70 @@ We kindly acknowledge NIST for reusing their content, including selection of pre
 #    Classes
 #################################################################
 
+###  http://emmo.info/emmo#MilliAmperePerSquareCentiMetre
+emmo:MilliAmperePerSquareCentiMetre rdf:type owl:Class ;
+                                               rdfs:subClassOf emmo:EMMO_120d86b6_d7c4_4490_8ef2_8a5f58403950 ,
+                                                               emmo:EMMO_60b78cc3_6011_4134_95ab_956f56d4bdc1 ,
+                                                               emmo:EMMO_a3a701ed_6f7d_4a10_9aee_dfa1961fc7b7 ,
+                                                               [ rdf:type owl:Restriction ;
+                                                                 owl:onProperty emmo:EMMO_8189b42e_0995_423a_a26c_51168b27c3cf ;
+                                                                 owl:hasValue "10.0"^^xsd:double
+                                                               ] ,
+                                                               [ rdf:type owl:Restriction ;
+                                                                 owl:onProperty emmo:EMMO_d088a3cb_d3e3_4eb2_9897_00aef0cb00cd ;
+                                                                 owl:hasValue "0.0"^^xsd:double
+                                                               ] ;
+                                               emmo:EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9 "0.001-fold of the SI base unit ampere divided by the 0.0001-fold  of the power of the SI base unit metre by exponent 2"@en ;
+                                               skos:prefLabel "MilliAmperePerSquareCentiMetre"@en .
+
+
+###  http://emmo.info/emmo#MilliAmpereHourPerSquareCentiMetre
+emmo:MilliAmpereHourPerSquareCentiMetre rdf:type owl:Class ;
+                                               rdfs:subClassOf emmo:EMMO_c6d4a5e0_7e95_44df_a6db_84ee0a8bbc8e ,
+                                                               [ rdf:type owl:Restriction ;
+                                                                 owl:onProperty emmo:EMMO_8189b42e_0995_423a_a26c_51168b27c3cf ;
+                                                                 owl:hasValue "36000000000.0"^^xsd:double
+                                                               ] ,
+                                                               [ rdf:type owl:Restriction ;
+                                                                 owl:onProperty emmo:EMMO_d088a3cb_d3e3_4eb2_9897_00aef0cb00cd ;
+                                                                 owl:hasValue "0.0"^^xsd:double
+                                                               ] ;
+                                               emmo:EMMO_33ae2d07_5526_4555_a0b4_8f4c031b5652 "mA.h.cm-2" ;
+                                               emmo:EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9 "unit of areic capacity"@en ;
+                                               skos:prefLabel "MilliAmpereHourPerSquareCentiMetre"@en .
+
+
+###  http://emmo.info/emmo#SquareCentMetrePerGram
+emmo:SquareCentMetrePerGram rdf:type owl:Class ;
+                                               rdfs:subClassOf emmo:EMMO_4817e479_e401_437e_a49b_54540b93d2a1 ,
+                                                               emmo:EMMO_60b78cc3_6011_4134_95ab_956f56d4bdc1 ,
+                                                               [ rdf:type owl:Restriction ;
+                                                                 owl:onProperty emmo:EMMO_8189b42e_0995_423a_a26c_51168b27c3cf ;
+                                                                 owl:hasValue "0.1"^^xsd:double
+                                                               ] ,
+                                                               [ rdf:type owl:Restriction ;
+                                                                 owl:onProperty emmo:EMMO_d088a3cb_d3e3_4eb2_9897_00aef0cb00cd ;
+                                                                 owl:hasValue "0.0"^^xsd:double
+                                                               ] ;
+                                               skos:prefLabel "SquareCentMetrePerGram"@en .
+
+
+###  http://emmo.info/emmo#MilliAmperePerGram
+emmo:MilliAmperePerGram rdf:type owl:Class ;
+                                               rdfs:subClassOf emmo:EMMO_1273eb34_de48_43a9_925f_104110469dd2 ,
+                                                               emmo:EMMO_73be8825_e9a7_41d0_956e_b58060e5d5ac ,
+                                                               [ rdf:type owl:Restriction ;
+                                                                 owl:onProperty emmo:EMMO_8189b42e_0995_423a_a26c_51168b27c3cf ;
+                                                                 owl:hasValue "1.0"^^xsd:double
+                                                               ] ,
+                                                               [ rdf:type owl:Restriction ;
+                                                                 owl:onProperty emmo:EMMO_d088a3cb_d3e3_4eb2_9897_00aef0cb00cd ;
+                                                                 owl:hasValue "0.0"^^xsd:double
+                                                               ] ;
+                                               emmo:EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9 "a unit of electric current per mass"@en ;
+                                               skos:prefLabel "MilliAmperePerGram"@en .
+
+
 ###  http://emmo.info/emmo#AttoCoulomb
 emmo:AttoCoulomb rdf:type owl:Class ;
                  rdfs:subClassOf emmo:EMMO_42955b2d_b465_4666_86cc_ea3c2d685753 ,

--- a/disciplines/units/siacceptedunits.ttl
+++ b/disciplines/units/siacceptedunits.ttl
@@ -33,6 +33,87 @@ We kindly acknowledge NIST for reusing their content, including the selection of
 #    Classes
 #################################################################
 
+###  http://emmo.info/emmo#AmpereHourPerLitre
+emmo:AmpereHourPerLitre rdf:type owl:Class ;
+                                               rdfs:subClassOf emmo:EMMO_8f36559a_a494_4b00_abc5_60bbc1475009 ,
+                                                               emmo:ac19c801_bead_4730_8b8c_50020eec45ec ,
+                                                               [ rdf:type owl:Restriction ;
+                                                                 owl:onProperty emmo:EMMO_8189b42e_0995_423a_a26c_51168b27c3cf ;
+                                                                 owl:hasValue "3600000.0"^^xsd:double
+                                                               ] ,
+                                                               [ rdf:type owl:Restriction ;
+                                                                 owl:onProperty emmo:EMMO_d088a3cb_d3e3_4eb2_9897_00aef0cb00cd ;
+                                                                 owl:hasValue "0.0"^^xsd:double
+                                                               ] ;
+                                               emmo:EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9 "a unit of electric charge per volume"@en ;
+                                               skos:prefLabel "AmpereHourPerLitre"@en .
+
+
+###  http://emmo.info/emmo#AmpereHourPerKilogram
+emmo:AmpereHourPerKilogram rdf:type owl:Class ;
+                                               rdfs:subClassOf emmo:EMMO_4dbe2b16_3e84_4049_898d_eb89bcc925a2 ,
+                                                               emmo:ac19c801_bead_4730_8b8c_50020eec45ec ,
+                                                               [ rdf:type owl:Restriction ;
+                                                                 owl:onProperty emmo:EMMO_8189b42e_0995_423a_a26c_51168b27c3cf ;
+                                                                 owl:hasValue "3600.0"^^xsd:double
+                                                               ] ,
+                                                               [ rdf:type owl:Restriction ;
+                                                                 owl:onProperty emmo:EMMO_d088a3cb_d3e3_4eb2_9897_00aef0cb00cd ;
+                                                                 owl:hasValue "0.0"^^xsd:double
+                                                               ] ;
+                                               emmo:EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9 "unit of electric charge relative to mass"@en ;
+                                               skos:prefLabel "AmpereHourPerKilogram"@en .
+
+
+###  http://emmo.info/emmo#WattHourPerKilogram
+:WattHourPerKilogram rdf:type owl:Class ;
+                                           rdfs:subClassOf :EMMO_847f1d9f_205e_46c1_8cb6_a9e479421f88 ,
+                                                           :ac19c801_bead_4730_8b8c_50020eec45ec ,
+                                                           [ rdf:type owl:Restriction ;
+                                                             owl:onProperty :EMMO_8189b42e_0995_423a_a26c_51168b27c3cf ;
+                                                             owl:hasValue "3600.0"^^xsd:double
+                                                           ] ,
+                                                           [ rdf:type owl:Restriction ;
+                                                             owl:onProperty :EMMO_d088a3cb_d3e3_4eb2_9897_00aef0cb00cd ;
+                                                             owl:hasValue "0.0"^^xsd:double
+                                                           ] ;
+                                           :EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9 "a unit of specific energy commonly used to measure the density of energy in batteries and capacitors"@en ;
+                                           :EMMO_c84c6752_6d64_48cc_9500_e54a3c34898d "https://en.wikipedia.org/wiki/Watt-hour_per_kilogram"@en ;
+                                           skos:prefLabel "WattHourPerKilogram"@en .
+
+
+###  http://emmo.info/emmo#WattHourPerLitre
+:WattHourPerLitre rdf:type owl:Class ;
+                                           rdfs:subClassOf :EMMO_53bd0c90_41c3_46e2_8779_cd2a80f7e18b ,
+                                                           :ac19c801_bead_4730_8b8c_50020eec45ec ,
+                                                           [ rdf:type owl:Restriction ;
+                                                             owl:onProperty :EMMO_8189b42e_0995_423a_a26c_51168b27c3cf ;
+                                                             owl:hasValue "3600000.0"^^xsd:double
+                                                           ] ,
+                                                           [ rdf:type owl:Restriction ;
+                                                             owl:onProperty :EMMO_d088a3cb_d3e3_4eb2_9897_00aef0cb00cd ;
+                                                             owl:hasValue "0.0"^^xsd:double
+                                                           ] ;
+                                           :EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9 "a unit of energy density commonly used to measure the density of energy in batteries and capacitors"@en ;
+                                           skos:prefLabel "WattHourPerLitre"@en .
+
+
+###  http://emmo.info/emmo#WattPerLitre
+emmo:WattPerLitre rdf:type owl:Class ;
+                                               rdfs:subClassOf emmo:EMMO_60b78cc3_6011_4134_95ab_956f56d4bdc1 ,
+                                                               emmo:EMMO_fced2382_9c23_47a1_8246_a5dcd45ad99c ,
+                                                               [ rdf:type owl:Restriction ;
+                                                                 owl:onProperty emmo:EMMO_8189b42e_0995_423a_a26c_51168b27c3cf ;
+                                                                 owl:hasValue "1000.0"^^xsd:double
+                                                               ] ,
+                                                               [ rdf:type owl:Restriction ;
+                                                                 owl:onProperty emmo:EMMO_d088a3cb_d3e3_4eb2_9897_00aef0cb00cd ;
+                                                                 owl:hasValue "0.0"^^xsd:double
+                                                               ] ;
+                                               emmo:EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9 "a unit for power per volume quantities"@en ;
+                                               skos:prefLabel "WattPerLitre"@en .
+
+
 ###  http://emmo.info/emmo#AmpereHour
 :AmpereHour rdf:type owl:Class ;
             rdfs:subClassOf :EMMO_ab79e92b_5377_454d_be06_d61b50db295a ,


### PR DESCRIPTION
adds unit classes for:

- MilliAmpereHourPerSquareCentiMetre
- SquareCentMetrePerGram
- MilliAmperePerGram
- AmperePerGram
- MilliAmperePerSquareCentiMetre
- SquareMetrePerGram
- AmpereHourPerLitre
- AmpereHourPerKilogram
- WattHourPerKilogram
- WattHourPerLitre
- WattPerLitre