### PR TITLE
Typos fixed in dataset IRI: discipline <- disciplines.

### DIFF
--- a/catalog-v001.xml
+++ b/catalog-v001.xml
@@ -37,7 +37,7 @@
         <uri name="https://w3id.org/emmo/1.0.0-rc3/disciplines/periodictable"       uri="./disciplines/periodictable.ttl"/>
         <uri name="https://w3id.org/emmo/1.0.0-rc3/disciplines/perceptual"          uri="./disciplines/perceptual.ttl"/>
         <uri name="https://w3id.org/emmo/1.0.0-rc3/disciplines/geometrical"         uri="./disciplines/geometrical.ttl"/>
-        <uri name="https://w3id.org/emmo/1.0.0-rc3/discipline/dataset"              uri="./discipline/dataset.ttl"/>
+        <uri name="https://w3id.org/emmo/1.0.0-rc3/disciplines/dataset"             uri="./disciplines/dataset.ttl"/>
 
         <uri name="https://w3id.org/emmo/1.0.0-rc3/disciplines/metrology"           uri="./disciplines/metrology.ttl"/>
         <uri name="https://w3id.org/emmo/1.0.0-rc3/disciplines/isq"                 uri="./disciplines/isq.ttl"/>

--- a/disciplines/dataset.ttl
+++ b/disciplines/dataset.ttl
@@ -8,8 +8,8 @@
 @prefix dcterms: <http://purl.org/dc/terms/> .
 @base <https://w3id.org/emmo#> .
 
-<https://w3id.org/emmo/discipline/dataset> rdf:type owl:Ontology ;
-                                                  owl:versionIRI <https://w3id.org/emmo/1.0.0-rc3/discipline/dataset> ;
+<https://w3id.org/emmo/disciplines/dataset> rdf:type owl:Ontology ;
+                                                  owl:versionIRI <https://w3id.org/emmo/1.0.0-rc3/disciplines/dataset> ;
                                                   owl:imports <https://w3id.org/emmo/1.0.0-rc3/reference/information> ,
                                                               <https://w3id.org/emmo/1.0.0-rc3/reference/symbolic> ;
                                                   dcterms:abstract "Shared representation of datasets."@en ;


### PR DESCRIPTION
Just a trivial typo in the IRI of dataset.ttl;
I have tested the change locally and it doesn't break the EMMO.