### PR TITLE
Fixed typo

### DIFF
--- a/disciplines/chemistry.ttl
+++ b/disciplines/chemistry.ttl
@@ -218,7 +218,7 @@ This qualifies a chemical element as a name and not a matter obejct that can sta
 ###  https://w3id.org/emmo#EMMO_91a0635a_a89a_46de_8928_04a777d145c7
 :EMMO_91a0635a_a89a_46de_8928_04a777d145c7 rdf:type owl:Class ;
                                            rdfs:subClassOf :EMMO_643d99dd_fae6_4121_a76f_47f486a4480b ;
-                                           skos:prefLabel "IUPACNomencalture"@en .
+                                           skos:prefLabel "IUPACNomenclature"@en .
 
 
 ###  https://w3id.org/emmo#EMMO_9236d0aa_cb39_43a1_bbdd_6a2a714951c8


### PR DESCRIPTION
The label of `https://w3id.org/emmo#EMMO_91a0635a_a89a_46de_8928_04a777d145c7` contained a typo which is fixed here.

"IUPACNomencalture" -> "IUPACNomenclature"