### PR TITLE
Fix syntax error in units.ttl

### DIFF
--- a/disciplines/units/units.ttl
+++ b/disciplines/units/units.ttl
@@ -19,7 +19,7 @@
                                                       <https://w3id.org/emmo/1.0.0-rc1/disciplines/units/siacceptedunits> ,
                                                       <https://w3id.org/emmo/1.0.0-rc1/disciplines/units/specialunits> ,
                                                       <https://w3id.org/emmo/1.0.0-rc1/disciplines/units/unclassifiedunits> ,
-                                                      <https://w3id.org/emmo/1.0.0-rc1/disciplines/units/otherunits> .
+                                                      <https://w3id.org/emmo/1.0.0-rc1/disciplines/units/otherunits> ;
                                           dcterms:abstract """A module that collects all units defined by EMMO.
 
 EMMO organises the units in the following set of modules:


### PR DESCRIPTION
This PR fixes a small syntax error in units.ttl that is disrupting its import and use. Line 22 ends with a period, where it should end with a semicolon. Test loading in protege confirms fix. 