### PR TITLE
Correct IRIs on generated html files on github pages.

### DIFF
--- a/.github/scripts/fixinferred.sh
+++ b/.github/scripts/fixinferred.sh
@@ -28,7 +28,7 @@ sed -e '/<owl:Ontology/q' \
     sed '/<owl:Ontology/s|/>|>|' > "$tmpfile"
 
 # -- add versionIRI
-echo "        <owl:versionIRI rdf:resource=\"http://emmo.info/emmo/$version/emmo-inferred\"/>" >> "$tmpfile"
+echo "        <owl:versionIRI rdf:resource=\"https://w3id.org/emmo/$version/emmo-inferred\"/>" >> "$tmpfile"
 
 # -- add ontology-wise annotations from emmo.owl
 sed -n '/<owl:Ontology/,/<\/owl:Ontology/p' "$rootdir/emmo.owl" | \
@@ -74,19 +74,19 @@ http://www.w3.org/2004/02/skos/core#prefLabel    http://www.w3.org/2000/01/rdf-s
 http://www.w3.org/2004/02/skos/core#altLabel     http://www.w3.org/2000/01/rdf-schema#label
 http://www.w3.org/2004/02/skos/core#hiddenLabel  http://www.w3.org/2000/01/rdf-schema#label
 
-http://emmo.info/emmo/top/annotations#EMMO_70fe84ff_99b6_4206_a9fc_9a8931836d84 http://www.w3.org/2000/01/rdf-schema#comment
-http://emmo.info/emmo/top/annotations#EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9 http://www.w3.org/2000/01/rdf-schema#comment
-http://emmo.info/emmo/top/annotations#EMMO_b432d2d5_25f4_4165_99c5_5935a7763c1a http://www.w3.org/2000/01/rdf-schema#comment
-http://emmo.info/emmo/middle/isq#EMMO_de178b12_5d35_4bca_8efa_a4193162571d      http://www.w3.org/2000/01/rdf-schema#comment
+https://w3id.org/emmo/top/annotations#EMMO_70fe84ff_99b6_4206_a9fc_9a8931836d84 http://www.w3.org/2000/01/rdf-schema#comment
+https://w3id.org/emmo/top/annotations#EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9 http://www.w3.org/2000/01/rdf-schema#comment
+https://w3id.org/emmo/top/annotations#EMMO_b432d2d5_25f4_4165_99c5_5935a7763c1a http://www.w3.org/2000/01/rdf-schema#comment
+https://w3id.org/emmo/middle/isq#EMMO_de178b12_5d35_4bca_8efa_a4193162571d      http://www.w3.org/2000/01/rdf-schema#comment
 
-http://emmo.info/emmo/top/annotations#EMMO_b306ae38_938e_48fe_83e9_6141e08b596f http://www.w3.org/2000/01/rdf-schema#seeAlso
-http://emmo.info/emmo/top/annotations#EMMO_6dd685dd_1895_46e4_b227_be9f7d643c25 http://www.w3.org/2000/01/rdf-schema#seeAlso
-http://emmo.info/emmo/top/annotations#EMMO_50c298c2_55a2_4068_b3ac_4e948c33181f http://www.w3.org/2000/01/rdf-schema#seeAlso
-http://emmo.info/emmo/top/annotations#EMMO_8de5d5bf_db1c_40ac_b698_095ba3b18578 http://www.w3.org/2000/01/rdf-schema#seeAlso
-http://emmo.info/emmo/top/annotations#EMMO_fe015383_afb3_44a6_ae86_043628697aa2 http://www.w3.org/2000/01/rdf-schema#seeAlso
-http://emmo.info/emmo/top/annotations#EMMO_e55f2d7c_9893_48cd_b4a4_fdf38253bd20 http://www.w3.org/2000/01/rdf-schema#seeAlso
-http://emmo.info/emmo/top/annotations#EMMO_1f1b164d_ec6a_4faa_8d5e_88bda62316cc http://www.w3.org/2000/01/rdf-schema#seeAlso
-http://emmo.info/emmo/top/annotations#EMMO_c84c6752_6d64_48cc_9500_e54a3c34898d http://www.w3.org/2000/01/rdf-schema#seeAlso
+https://w3id.org/emmo/top/annotations#EMMO_b306ae38_938e_48fe_83e9_6141e08b596f http://www.w3.org/2000/01/rdf-schema#seeAlso
+https://w3id.org/emmo/top/annotations#EMMO_6dd685dd_1895_46e4_b227_be9f7d643c25 http://www.w3.org/2000/01/rdf-schema#seeAlso
+https://w3id.org/emmo/top/annotations#EMMO_50c298c2_55a2_4068_b3ac_4e948c33181f http://www.w3.org/2000/01/rdf-schema#seeAlso
+https://w3id.org/emmo/top/annotations#EMMO_8de5d5bf_db1c_40ac_b698_095ba3b18578 http://www.w3.org/2000/01/rdf-schema#seeAlso
+https://w3id.org/emmo/top/annotations#EMMO_fe015383_afb3_44a6_ae86_043628697aa2 http://www.w3.org/2000/01/rdf-schema#seeAlso
+https://w3id.org/emmo/top/annotations#EMMO_e55f2d7c_9893_48cd_b4a4_fdf38253bd20 http://www.w3.org/2000/01/rdf-schema#seeAlso
+https://w3id.org/emmo/top/annotations#EMMO_1f1b164d_ec6a_4faa_8d5e_88bda62316cc http://www.w3.org/2000/01/rdf-schema#seeAlso
+https://w3id.org/emmo/top/annotations#EMMO_c84c6752_6d64_48cc_9500_e54a3c34898d http://www.w3.org/2000/01/rdf-schema#seeAlso
 EOF
 
 echo "</rdf:RDF>" >> "$tmpfile"

--- a/.github/scripts/makeindex.sh
+++ b/.github/scripts/makeindex.sh
@@ -13,7 +13,7 @@ set -e
 # Configurations
 pages_url="https://emmo-repo.github.io"
 pages_versions_url="$pages_url/versions"
-emmo_url="http://emmo.info/emmo"
+emmo_url="https://w3id.org/emmo"
 
 rootdir="$(git rev-parse --show-toplevel)"
 ghdir="$rootdir/.github"

--- a/.github/scripts/makeversions.sh
+++ b/.github/scripts/makeversions.sh
@@ -107,11 +107,11 @@ while read version name; do
     #if $remake || [ ! -f "$d/emmo-renamed.owl" ]; then
     #    echo "Generate renamed ontology"
     #    ontoconvert "$d/emmo-inferred.ttl" "$d/emmo-renamed.owl" \
-    #                -w -R -b http://emmo.info/emmo-renamed || true
+    #                -w -R -b https://w3id.org/emmo-renamed || true
     #fi
     #if $remake || [ ! -f "$d/emmo-renamed.ttl" ]; then
     #    ontoconvert "$d/emmo-inferred.ttl" "$d/emmo-renamed.ttl" \
-    #                -w -R -b http://emmo.info/emmo-renamed || true
+    #                -w -R -b https://w3id.org/emmo-renamed || true
     #fi
 
     # Generate documentation

--- a/.github/versions.txt
+++ b/.github/versions.txt
@@ -1,5 +1,6 @@
-1.0.0          development
-1.0.0-rc3      stable
+1.0.1          development
+1.0.0          stable
+1.0.0-rc3
 1.0.0-rc2
 1.0.0-rc1
 1.0.0-beta7


### PR DESCRIPTION
Update EMMO IRIs from the old http://emmo.info/ to https://w3id.org/ in the scripts generating the content on GitHub Pages.

The IRIs on https://emmo-repo.github.io/ has been manually corrected. But will be overwritten to emmo.info without this PR.

This PR can be merged directly to master, since it doesn't touch the ontology.