### PR TITLE
Made IRI of hasORCID human readable

### DIFF
--- a/contributors.ttl
+++ b/contributors.ttl
@@ -24,11 +24,12 @@
 #    Data properties
 #################################################################
 
-###  https://w3id.org/emmo/contributors#EMMO_e117f976_7a5d_4508_bf85_9226dca58e1f
-:EMMO_e117f976_7a5d_4508_bf85_9226dca58e1f rdf:type owl:DatatypeProperty ;
+###  https://w3id.org/emmo#hasORCID
+:hasORCID rdf:type owl:DatatypeProperty ;
     rdfs:range xsd:anyURI ;
     rdfs:comment "Relates an individual to an ORCID that identifies the individual."@en ,
     "The domain is not provided to not impose restrictions on the individual carrying the ORCID. Typically it will be a person (maximal) or a temporal part of a person."@en ;
+    rdfs:subPropertyOf dcterms:identifier ;
     skos:prefLabel "hasORCID"@en .
 
 
@@ -41,83 +42,83 @@
 # ======
 
 :EmanueleGhedini rdf:type owl:NamedIndividual ;
-    :EMMO_e117f976_7a5d_4508_bf85_9226dca58e1f "https://orcid.org/0000-0003-3805-8761"^^xsd:anyURI ;
+    :hasORCID "https://orcid.org/0000-0003-3805-8761"^^xsd:anyURI ;
     skos:prefLabel "EmanueleGhedini" ;
     foaf:name "Emanuele Ghedini" ;
     foaf:workplaceHomepage <https://www.unibo.it/en/> .
 
 
 :JesperFriis rdf:type owl:NamedIndividual ;
-    :EMMO_e117f976_7a5d_4508_bf85_9226dca58e1f "https://orcid.org/0000-0002-1560-809X"^^xsd:anyURI ;
+    :hasORCID "https://orcid.org/0000-0002-1560-809X"^^xsd:anyURI ;
     skos:prefLabel "JesperFriis" ;
     foaf:name "Jesper Friis" ;
     foaf:workplaceHomepage <https://www.sintef.no/en/> .
 
 
 :GerhardGoldbeck rdf:type owl:NamedIndividual ;
-    :EMMO_e117f976_7a5d_4508_bf85_9226dca58e1f "https://orcid.org/0000-0002-4181-2852"^^xsd:anyURI ;
+    :hasORCID "https://orcid.org/0000-0002-4181-2852"^^xsd:anyURI ;
     skos:prefLabel "GerhardGoldbeck" ;
     foaf:name "Gerhard Goldbeck" ;
     foaf:workplaceHomepage <https://materialsmodelling.com/> .
 
 
 :AdhamHashibon rdf:type owl:NamedIndividual ;
-    :EMMO_e117f976_7a5d_4508_bf85_9226dca58e1f "https://orcid.org/0000-0003-0514-9229"^^xsd:anyURI ;
+    :hasORCID "https://orcid.org/0000-0003-0514-9229"^^xsd:anyURI ;
     skos:prefLabel "AdhamHashibon" ;
     foaf:name "Adham Hashibon" ;
     foaf:workplaceHomepage <https://www.ucl.ac.uk/> .
 
 
 :GeorgSchmitz rdf:type owl:NamedIndividual ;
-    :EMMO_e117f976_7a5d_4508_bf85_9226dca58e1f "https://orcid.org/0000-0003-4065-9742"^^xsd:anyURI ;
+    :hasORCID "https://orcid.org/0000-0003-4065-9742"^^xsd:anyURI ;
     skos:prefLabel "GeorgJSchmitz" ;
     foaf:name "Georg J. Schmitz" .
 
 
 :AnnedeBaas rdf:type owl:NamedIndividual ;
-    :EMMO_e117f976_7a5d_4508_bf85_9226dca58e1f "https://orcid.org/0009-0007-5850-6628"^^xsd:anyURI ;
+    :hasORCID "https://orcid.org/0009-0007-5850-6628"^^xsd:anyURI ;
     skos:prefLabel "AnnedeBaas" ;
     foaf:name "Anne de Baas" ;
     foaf:workplaceHomepage <https://materialsmodelling.com/> .
 
 
 :FrancescoZaccarini rdf:type owl:NamedIndividual ;
-    :EMMO_e117f976_7a5d_4508_bf85_9226dca58e1f "https://orcid.org/0009-0008-8009-5009"^^xsd:anyURI ;
+    :hasORCID "https://orcid.org/0009-0008-8009-5009"^^xsd:anyURI ;
     skos:prefLabel "FrancescoZaccarini" ;
     foaf:name "Francesco A. Zaccarini" ;
     foaf:workplaceHomepage <https://www.unibo.it/en/> .
 
 
 :SebastianoMoruzzi rdf:type owl:NamedIndividual ;
-    :EMMO_e117f976_7a5d_4508_bf85_9226dca58e1f "https://orcid.org/0000-0001-9189-2400"^^xsd:anyURI ;
+    :hasORCID "https://orcid.org/0000-0001-9189-2400"^^xsd:anyURI ;
     skos:prefLabel "SebastianoMoruzzi" ;
     foaf:name "Sebastiano Moruzzi" ;
     foaf:workplaceHomepage <https://www.unibo.it/en/> .
 
 
 :FrancescaBleken rdf:type owl:NamedIndividual ;
-    :EMMO_e117f976_7a5d_4508_bf85_9226dca58e1f "https://orcid.org/0000-0001-8869-3718"^^xsd:anyURI ;
+    :hasORCID "https://orcid.org/0000-0001-8869-3718"^^xsd:anyURI ;
     skos:prefLabel "FrancescaLonstadBleken" ;
     foaf:name "Francesca Lønstad Bleken" ;
     foaf:workplaceHomepage <https://www.sintef.no/en/> .
 
 
 :SimonClark rdf:type owl:NamedIndividual ;
-    :EMMO_e117f976_7a5d_4508_bf85_9226dca58e1f "https://orcid.org/0000-0002-8758-6109"^^xsd:anyURI ;
+    :hasORCID "https://orcid.org/0000-0002-8758-6109"^^xsd:anyURI ;
     skos:prefLabel "SimonClark" ;
     foaf:name "Simon Clark" ;
     foaf:workplaceHomepage <https://www.sintef.no/en/> .
 
 
 :OtelloRoscioni rdf:type owl:NamedIndividual ;
-    :EMMO_e117f976_7a5d_4508_bf85_9226dca58e1f "https://orcid.org/0000-0001-7815-6636"^^xsd:anyURI ;
+    :hasORCID "https://orcid.org/0000-0001-7815-6636"^^xsd:anyURI ;
     skos:prefLabel "OtelloMRoscioni" ;
     foaf:name "Otello M. Roscioni" ;
     foaf:workplaceHomepage <https://materialsmodelling.com/> .
 
 
 :MichaelNorske rdf:type owl:NamedIndividual ;
-    :EMMO_e117f976_7a5d_4508_bf85_9226dca58e1f "https://orcid.org/0000-0002-5417-6808"^^xsd:anyURI ;
+    :hasORCID "https://orcid.org/0000-0002-5417-6808"^^xsd:anyURI ;
     skos:prefLabel "PaulLudwigMichaelNoeske" ;
     foaf:name "Paul-Ludwig Michael Noeske" ;
     foaf:workplaceHomepage <https://www.ifam.fraunhofer.de/en/> .


### PR DESCRIPTION
### Motivation
Users may want to look at the contributors.ttl file as-is.

Replacing the numerical IRI for hasORCID to emmo:hasORCID makes the file much easier to read.
    
Furthermore, the contributors.ttl file defines only the contributing people and organisations, but is not part of EMMO per see. There is therefor no strong argument to keep the numerical IRI for hasORCID.
