### PR TITLE
Make procedure nonsemiotic

### DIFF
--- a/reference/workflow.ttl
+++ b/reference/workflow.ttl
@@ -138,13 +138,8 @@ It means that you can declare that e.g. tightening a bolt is a task of building 
 :EMMO_472a0ca2_58bf_4618_b561_6fe68bd9fd49 rdf:type owl:Class ;
                                            rdfs:subClassOf :EMMO_bafc17b5_9be4_4823_8bbe_ab4e90b6738c ,
                                                            [ rdf:type owl:Restriction ;
-                                                             owl:onProperty :EMMO_60577dea_9019_4537_ac41_80b0fb563d41 ;
+                                                             owl:onProperty :EMMO_b3c8ba10_6bee_45e7_9416_e9019aa9f023 ;
                                                              owl:someValuesFrom :EMMO_eaf4640d_651d_4cbe_a315_3d2dc5df3b35
-                                                           ] ,
-                                                           [ rdf:type owl:Restriction ;
-                                                             owl:onProperty [ owl:inverseOf :EMMO_f2fc1ce9_cc3b_4eb5_a112_3c85d1b1374a
-                                                                            ] ;
-                                                             owl:someValuesFrom :EMMO_8cf62c94_ae5f_4f80_8669_d5f91178db6d
                                                            ] ;
                                            skos:altLabel "Elaboration"@en ,
                                                          "Work"@en ;


### PR DESCRIPTION
Removed semiotic restrictions from procedure, since that will make it a semiosis and a referent at the same time.

Changes:
* removed
  - Procedure: inverse (providesInterpretation) some ProceduralAgent
  - Procedure: isRepresentedBy some ProceduralData
 
* added
  - Procedure: properOverlaps some ProceduralData