### PR TITLE
Quantity is not a referent

### DIFF
--- a/disciplines/metrology.ttl
+++ b/disciplines/metrology.ttl
@@ -246,7 +246,7 @@ The quantity is selected without an observation aimed to measure its actual valu
 
 ###  https://w3id.org/emmo#EMMO_67fc0a36_8dcb_4ffa_9a43_31074efa3296
 :EMMO_67fc0a36_8dcb_4ffa_9a43_31074efa3296 rdf:type owl:ObjectProperty ;
-                                           rdfs:subPropertyOf :EMMO_eb3518bf_f799_4f9e_8c3e_ce59af11453b ;
+                                           rdfs:subPropertyOf :EMMO_55375713_8f92_473b_a688_b7fcc14f7797 ;
                                            rdf:type owl:InverseFunctionalProperty ,
                                                     owl:AsymmetricProperty ,
                                                     owl:IrreflexiveProperty ;
@@ -297,6 +297,7 @@ The label of this class was also changed from PhysicsDimension to PhysicalDimens
 ###  https://w3id.org/emmo#EMMO_88b84515_a0df_47bb_8166_c7c8b893c1d8
 :EMMO_88b84515_a0df_47bb_8166_c7c8b893c1d8 rdf:type owl:ObjectProperty ;
                                            rdfs:subPropertyOf :EMMO_eb3518bf_f799_4f9e_8c3e_ce59af11453b ;
+                                           owl:inverseOf :EMMO_a97351bc_1b1b_4157_95b7_0a60ac56b8e2 ;
                                            rdfs:domain :EMMO_0650c031_42b6_4f0a_b62d_d88f071da6bf ;
                                            rdfs:range :EMMO_f658c301_ce93_46cf_9639_4eace2c5d1d5 ;
                                            skos:prefLabel "hasQuantityValue"@en ;
@@ -327,7 +328,6 @@ The label of this class was also changed from PhysicsDimension to PhysicalDimens
 ###  https://w3id.org/emmo#EMMO_a97351bc_1b1b_4157_95b7_0a60ac56b8e2
 :EMMO_a97351bc_1b1b_4157_95b7_0a60ac56b8e2 rdf:type owl:ObjectProperty ;
                                            rdfs:subPropertyOf :EMMO_55375713_8f92_473b_a688_b7fcc14f7797 ;
-                                           owl:inverseOf :EMMO_eb3518bf_f799_4f9e_8c3e_ce59af11453b ;
                                            skos:prefLabel "isQuantityValueFor"@en .
 
 


### PR DESCRIPTION
A Quantity is a sign. However, the restriction
    
        Quantity hasMetrologicalReference exactly 1 MetrologicalReference
    
also makes it a Referent since hasMetrologicalReference is a subproperty of hasConvention which has domain Referent.
    
This can be avoided by making MetrologicalReference a subproperty of isConventionFor instead.
This fix is implemented in this PR.
    
**Unrelated bugfix**: We changed the inverse of isQuantityValueFor to hasQuanitityValue instead of hasConvention.
